### PR TITLE
Fixed typo on the creator landing page

### DIFF
--- a/src/templates/generator-landing.html.twig
+++ b/src/templates/generator-landing.html.twig
@@ -18,7 +18,7 @@
 
 <ul>
     <li><em>Tylko 3 minuty</em> Szybko wybierz problem, adresata i rodzaj pisma</li>
-    <li><em>100% Unikalne Pisma</em> Napiszamy Ci spersonalizowany tekst, by twój głos był słyszalny i skuteczny</li>
+    <li><em>100% Unikalne Pisma</em> Napiszemy Ci spersonalizowany tekst, by twój głos był słyszalny i skuteczny</li>
     <li><em>Zacznij Działać Teraz!</em> Wyślij pismo i dotrzyj do decydentów</li>
 </ul>
 


### PR DESCRIPTION
There's a typo on creator's landing page "Napiszamy" instead of "Napiszemy" and this PR fixes it.

<img width="845" height="497" alt="Zrzut ekranu 2025-10-16 o 10 56 38" src="https://github.com/user-attachments/assets/bc076dd9-ff05-4db9-8fb6-e8e15f124265" />
