### PR TITLE
fix#34 Geolocation UI problems while submitting a new report

### DIFF
--- a/src/js/lib/geolocation.js
+++ b/src/js/lib/geolocation.js
@@ -52,8 +52,8 @@ export function initMaps(lastLocation, _stopAgresji) {
 
   map.addControl(new mapboxgl.GeolocateControl({
     positionOptions: { enableHighAccuracy: true },
-    trackUserLocation: true,
-    showUserHeading: true
+    trackUserLocation: false,
+    showUserHeading: false
   }), 'top-left')
 
   map.dragRotate.disable()


### PR DESCRIPTION
Fixed by removing empty `setSM()` (which clears the UI) that was triggered before double request to map APIs.