### PR TITLE
Fix security workflow - remove PHP from CodeQL

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,13 +60,14 @@ jobs:
           sarif_file: 'semgrep-results.sarif'
 
   # Deep code analysis - runs on PRs and pushes to main
+  # Note: CodeQL does not support PHP (as of 2025). PHP security covered by Semgrep.
   codeql-analysis:
     name: CodeQL - Code Analysis
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        language: [javascript, python, php]
+        language: [javascript, python]
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.2.2


### PR DESCRIPTION
## Motivation

Security workflow failing because CodeQL doesn't support PHP language.

Error from workflow run: `Did not recognize the following languages: php`

## Implementation information

**Root cause:** CodeQL does not support PHP as of 2025 ([GitHub discussion](https://github.com/orgs/community/discussions/158392)). Despite PHP being a top 10 language on GitHub, it remains unsupported.

**Solution:** Remove PHP from CodeQL language matrix. PHP security analysis still covered by:
- **Semgrep** - SAST for PHP code (SQL injection, XSS, path traversal, etc.)
- **Trivy** - Composer dependency vulnerability scanning

**Change:** Updated `.github/workflows/security.yml` line 70 to only scan JavaScript and Python with CodeQL.

## Supporting documentation

- [CodeQL supported languages](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/) - PHP not listed
- [GitHub community discussion #158392](https://github.com/orgs/community/discussions/158392) - "CodeQL does not support PHP"
- [Failed workflow run](https://github.com/uprzejmiedonosze/uprzejmiedonosze/actions/runs/20161481262/job/57874739646) - demonstrates the error