### PR TITLE
fix(ci): Enable security workflow on main and staging branches

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,134 @@
+name: Security Scanning
+
+on:
+  pull_request:
+    branches: [main, staging]
+  push:
+    branches: [main, staging]
+  schedule:
+    # Weekly deep scan every Monday at 3 AM UTC
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: read
+
+jobs:
+  # Fast dependency scanning - runs on PRs
+  trivy-scan:
+    name: Trivy - Dependency Scanning
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.2.2
+
+      - name: Run Trivy scanner
+        uses: aquasecurity/trivy-action@22438a435773de8c97dc0958cc0b823c45b064ac # master 2025-12-11
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@1b0b941e1fbd5cb8122c5ebdf087be9d02534840 # v3.27.9
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  # SAST security rules - runs on PRs
+  semgrep-scan:
+    name: Semgrep - SAST Analysis
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.2.2
+
+      - name: Run Semgrep
+        run: semgrep scan --config auto --sarif --output semgrep-results.sarif || true
+
+      - name: Upload Semgrep results to GitHub Security
+        uses: github/codeql-action/upload-sarif@1b0b941e1fbd5cb8122c5ebdf087be9d02534840 # v3.27.9
+        if: always()
+        with:
+          sarif_file: 'semgrep-results.sarif'
+
+  # Deep code analysis - runs on PRs and pushes to main
+  # Note: CodeQL does not support PHP (as of 2025). PHP security covered by Semgrep.
+  codeql-analysis:
+    name: CodeQL - Code Analysis
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript, python]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@1b0b941e1fbd5cb8122c5ebdf087be9d02534840 # v3.27.9
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@1b0b941e1fbd5cb8122c5ebdf087be9d02534840 # v3.27.9
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  # Secret scanning - runs on pushes to main and weekly
+  secret-scanning:
+    name: TruffleHog - Secret Detection
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog Secret Scanning
+        uses: trufflesecurity/trufflehog@05cccb53bc9e13bc6d17997db5a6bcc3df44bf2f # main 2025-12-11
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --only-verified
+
+  # Comprehensive audit - runs weekly
+  dependency-audit:
+    name: Full Dependency Audit
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.2.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.32.1
+        with:
+          php-version: '8.2'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v4.2.0
+        with:
+          node-version: '20'
+
+      - name: Install Composer dependencies
+        run: composer install --no-dev --ignore-platform-reqs
+
+      - name: Composer security audit
+        run: composer audit --format=plain
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: npm security audit
+        run: npm audit --audit-level=moderate


### PR DESCRIPTION
## Motivation

Security workflow currently only runs on `staging` branch, missing security checks on `main` branch commits.

## Implementation information

Updated workflow triggers to monitor both branches:
- PRs to `main` or `staging` → run security scans
- Pushes to `main` or `staging` → run security scans
- Weekly cron → unchanged

**Change:** `.github/workflows/security.yml` lines 5-7

```yaml
# Before
branches: [staging]

# After
branches: [main, staging]
```

## Supporting documentation

Ensures security coverage across both primary deployment branches:
- `staging` → staging.uprzejmiedonosze.net
- `main` → uprzejmiedonosze.net (production)