### PR TITLE
fix(stats): responsive charts for mobile

### DIFF
--- a/src/js/sites/statistics.js
+++ b/src/js/sites/statistics.js
@@ -76,6 +76,7 @@ document.addEventListener("DOMContentLoaded", function () {
     chart: {
       type: "areaspline",
       backgroundColor: "transparent",
+      reflow: true,
       events: {
         load() {
           const chart = this;
@@ -119,6 +120,18 @@ document.addEventListener("DOMContentLoaded", function () {
     tooltip: {
       shared: true,
       crosshairs: true
+    },
+    responsive: {
+      rules: [{
+        condition: {
+          maxWidth: 560
+        },
+        chartOptions: {
+          chart: {
+            height: 250
+          }
+        }
+      }]
     }
   });
 
@@ -134,6 +147,7 @@ document.addEventListener("DOMContentLoaded", function () {
       type: "column",
       plotBackgroundColor: null,
       backgroundColor: "transparent",
+      reflow: true,
       events: {
         load() {
           const chart = this;
@@ -176,6 +190,18 @@ document.addEventListener("DOMContentLoaded", function () {
     tooltip: {
       shared: true,
       crosshairs: true
+    },
+    responsive: {
+      rules: [{
+        condition: {
+          maxWidth: 560
+        },
+        chartOptions: {
+          chart: {
+            height: 250
+          }
+        }
+      }]
     }
   });
 
@@ -209,6 +235,7 @@ document.addEventListener("DOMContentLoaded", function () {
       plotShadow: false,
       type: "pie",
       backgroundColor: "transparent",
+      reflow: true,
       events: {
         load() {
           const chart = this;
@@ -244,6 +271,23 @@ document.addEventListener("DOMContentLoaded", function () {
         center: ["50%", "75%"],
         size: "110%"
       }
+    },
+    responsive: {
+      rules: [{
+        condition: {
+          maxWidth: 560
+        },
+        chartOptions: {
+          chart: {
+            height: 250
+          },
+          plotOptions: {
+            pie: {
+              size: "100%"
+            }
+          }
+        }
+      }]
     }
   });
 });

--- a/src/templates/statystyki.html.twig
+++ b/src/templates/statystyki.html.twig
@@ -11,12 +11,12 @@
 <h2>Statystyki</h2>
 
 <p>Nowe zgłoszenia oraz nowi użytkownicy – ostatnie trzydzieści dni.</p>
-<div id="statsByDay" style="min-width: 300px; height: 300px; margin: 0 auto"></div>
+<div id="statsByDay" style="height: 300px; margin: 0 auto"></div>
 
 <p>Nowe zgłoszenia oraz nowi użytkownicy – układ miesięczny.</p>
-<div id="statsByYear" style="min-width: 300px; height: 300px; margin: 0 auto"></div>
+<div id="statsByYear" style="height: 300px; margin: 0 auto"></div>
 
 <p>TOP 10 najpopularniejszych marek pojazdów sprawcy.</p>
-<div id="statsByCarBrand" style="min-width: 250px; height: 300px; margin: 0 auto"></div>
+<div id="statsByCarBrand" style="height: 300px; margin: 0 auto"></div>
 
 {% endblock %}


### PR DESCRIPTION
## Motivation

Charts on statistics page don't adapt well to mobile devices, causing horizontal overflow and poor user experience on smaller screens.

## Implementation information

- Added `reflow: true` to all three Highcharts configurations (areaspline, column, pie)
- Implemented responsive rules with breakpoint at 560px to reduce chart height to 250px on mobile
- Adjusted pie chart size from 110% to 100% on mobile to prevent overflow
- Removed `min-width` CSS constraints from chart containers in template

## Supporting documentation

Fix: https://github.com/uprzejmiedonosze/uprzejmiedonosze/issues/46