### PR TITLE
Security hardening against CSRF and XSS attacks

### DIFF
--- a/config.dev.php
+++ b/config.dev.php
@@ -15,3 +15,4 @@ define('CRYPTO_IV', '330adc20ed7dcf8561ff4869dd434b85');
 define('CRYPTO_TAG', '190181339ab13a971415e977b736053f');
 
 define('BACKEND_API_KEY', 'dev-secret-key-change-in-production');
+define('CORS_ALLOWED_DOMAIN', 'localhost'); // includes subdomains

--- a/src/api/rest/index.php
+++ b/src/api/rest/index.php
@@ -66,13 +66,17 @@ $app->options('/{routes:.+}', function ($request, $response) {
 
 $app->add(function ($request, $handler) {
     $response = $handler->handle($request);
-    return $response
-            ->withHeader('Access-Control-Allow-Origin', '*')
+
+    $allowedOrigin = getCorsOrigin($request);
+    if ($allowedOrigin) {
+        $response = $response
+            ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
             ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
             ->withHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PATCH')
-            ->withHeader('Access-Control-Allow-Credentials', 'true')
-            ->withHeader('Content-Type', 'application/json')
-            ->withHeader('Content-Type', 'application/json; charset=UTF-8');
+            ->withHeader('Access-Control-Allow-Credentials', 'true');
+    }
+
+    return $response->withHeader('Content-Type', 'application/json; charset=UTF-8');
 });
 
 $app->group('/api/rest/user', function (RouteCollectorProxy $group) { // USER

--- a/src/inc/middleware/CsvMiddleware.php
+++ b/src/inc/middleware/CsvMiddleware.php
@@ -10,10 +10,16 @@ class CsvMiddleware implements MiddlewareInterface {
         logger(static::class . ": {$request->getUri()->getPath()}");
         $request = $request->withAttribute('content', 'csv');
         $response = $handler->handle($request);
-        return $response
-            ->withHeader('Access-Control-Allow-Origin', '*')
-            ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
-            ->withHeader('Access-Control-Allow-Methods', 'GET')
-            ->withHeader('Content-Type', 'text/csv');
+
+        $allowedOrigin = getCorsOrigin($request);
+        if ($allowedOrigin) {
+            $response = $response
+                ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
+                ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
+                ->withHeader('Access-Control-Allow-Methods', 'GET')
+                ->withHeader('Access-Control-Allow-Credentials', 'true');
+        }
+
+        return $response->withHeader('Content-Type', 'text/csv');
     }
 }

--- a/src/inc/middleware/HtmlMiddleware.php
+++ b/src/inc/middleware/HtmlMiddleware.php
@@ -63,11 +63,16 @@ class HtmlMiddleware implements MiddlewareInterface {
         $request = $request->withAttribute('parameters', $parameters);
 
         $response = $handler->handle($request);
-        return $response
-                ->withHeader('Access-Control-Allow-Origin', '*')
+
+        $allowedOrigin = getCorsOrigin($request);
+        if ($allowedOrigin) {
+            $response = $response
+                ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
                 ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
                 ->withHeader('Access-Control-Allow-Methods', 'GET, POST')
-                ->withHeader('Access-Control-Allow-Credentials', 'true')
-                ->withHeader('Content-Type', 'text/html; charset=UTF-8');
+                ->withHeader('Access-Control-Allow-Credentials', 'true');
+        }
+
+        return $response->withHeader('Content-Type', 'text/html; charset=UTF-8');
     }
 }

--- a/src/inc/middleware/JpegMiddleware.php
+++ b/src/inc/middleware/JpegMiddleware.php
@@ -10,10 +10,17 @@ class JpegMiddleware implements MiddlewareInterface {
         logger(static::class . ": {$request->getUri()->getPath()}");
         $request = $request->withAttribute('content', 'image');
         $response = $handler->handle($request);
+
+        $allowedOrigin = getCorsOrigin($request);
+        if ($allowedOrigin) {
+            $response = $response
+                ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
+                ->withHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, Origin')
+                ->withHeader('Access-Control-Allow-Methods', 'GET')
+                ->withHeader('Access-Control-Allow-Credentials', 'true');
+        }
+
         return $response
-            ->withHeader('Access-Control-Allow-Origin', '*')
-            ->withHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, Origin')
-            ->withHeader('Access-Control-Allow-Methods', 'GET')
             ->withHeader('Cache-Control', 'public, max-age=604800')
             ->withHeader('Content-Type', 'image/jpeg');
     }

--- a/src/inc/middleware/JsonMiddleware.php
+++ b/src/inc/middleware/JsonMiddleware.php
@@ -10,11 +10,16 @@ class JsonMiddleware implements MiddlewareInterface {
         //logger(static::class . ": {$request->getUri()->getPath()}");
         $request = $request->withAttribute('content', 'json');
         $response = $handler->handle($request);
-        return $response
-            ->withHeader('Access-Control-Allow-Origin', '*')
-            ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
-            ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH')
-            ->withHeader('Access-Control-Allow-Credentials', 'true')
-            ->withHeader('Content-Type', 'application/json; charset=UTF-8');
+
+        $allowedOrigin = getCorsOrigin($request);
+        if ($allowedOrigin) {
+            $response = $response
+                ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
+                ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
+                ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH')
+                ->withHeader('Access-Control-Allow-Credentials', 'true');
+        }
+
+        return $response->withHeader('Content-Type', 'application/json; charset=UTF-8');
     }
 }

--- a/src/inc/middleware/PdfMiddleware.php
+++ b/src/inc/middleware/PdfMiddleware.php
@@ -10,11 +10,17 @@ class PdfMiddleware implements MiddlewareInterface {
         logger(static::class . ": {$request->getUri()->getPath()}");
         $request = $request->withAttribute('content', 'pdf');
         $response = $handler->handle($request);
+
+        $allowedOrigin = getCorsOrigin($request);
+        if ($allowedOrigin) {
+            $response = $response
+                ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
+                ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
+                ->withHeader('Access-Control-Allow-Methods', 'GET')
+                ->withHeader('Access-Control-Allow-Credentials', 'true');
+        }
+
         return $response
-            ->withHeader('Access-Control-Allow-Origin', '*')
-            ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
-            ->withHeader('Access-Control-Allow-Methods', 'GET')
-            ->withHeader('Access-Control-Allow-Credentials', 'false')
             ->withHeader('Content-Type', 'application/pdf')
             ->withHeader('Content-Transfer-Encoding', 'Binary');
     }

--- a/src/inc/middleware/XlsMiddleware.php
+++ b/src/inc/middleware/XlsMiddleware.php
@@ -10,10 +10,16 @@ class XlsMiddleware implements MiddlewareInterface {
         logger(static::class . ": {$request->getUri()->getPath()}");
         $request = $request->withAttribute('content', 'xlsx');
         $response = $handler->handle($request);
-        return $response
-            ->withHeader('Access-Control-Allow-Origin', '*')
-            ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
-            ->withHeader('Access-Control-Allow-Methods', 'GET')
-            ->withHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+
+        $allowedOrigin = getCorsOrigin($request);
+        if ($allowedOrigin) {
+            $response = $response
+                ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
+                ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
+                ->withHeader('Access-Control-Allow-Methods', 'GET')
+                ->withHeader('Access-Control-Allow-Credentials', 'true');
+        }
+
+        return $response->withHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     }
 }

--- a/src/inc/utils.php
+++ b/src/inc/utils.php
@@ -138,3 +138,36 @@ function __domainUsesGoogleMail(string $domain) { // unused
 
     return false;
 }
+
+/**
+ * Get the appropriate CORS origin header value based on request origin
+ * Supports exact domain match and wildcard subdomain matching (*.domain.com)
+ *
+ * @param \Psr\Http\Message\ServerRequestInterface $request The PSR-7 request object
+ * @return string|null The allowed origin, or null if origin not allowed
+ */
+function getCorsOrigin(\Psr\Http\Message\ServerRequestInterface $request): ?string {
+    $origin = $request->getHeaderLine('Origin');
+
+    if (empty($origin))
+        return null;
+
+    $parsedOrigin = parse_url($origin);
+    if (!isset($parsedOrigin['host']))
+        return null;
+
+    $originHost = $parsedOrigin['host'];
+    $allowedDomain = CORS_ALLOWED_DOMAIN;
+
+    if ($originHost === $allowedDomain)
+        return $origin;
+
+    if (str_ends_with($originHost, '.' . $allowedDomain))
+        return $origin;
+
+    // failsafe to allow localhost and 127.0.0.1
+    if (isDev() && ($originHost === 'localhost' || $originHost === '127.0.0.1'))
+        return $origin;
+
+    return null;
+}

--- a/src/index.php
+++ b/src/index.php
@@ -19,6 +19,10 @@ if (session_status() == PHP_SESSION_NONE && !isset($_GET["sessionless"])) {
     ini_set("session.gc_maxlifetime", $timeout);
     ini_set("session.cookie_lifetime", $timeout);
 
+    ini_set("session.cookie_httponly", "1");
+    ini_set("session.cookie_secure", isProd() ? "1" : "0");
+    ini_set("session.cookie_samesite", "Lax");
+
     set_error_handler(fn($errno, $errstr) => logger($errstr), E_WARNING);
     session_start();
     $_SESSION['user_agent'] = $_SERVER['HTTP_USER_AGENT'] ?? '(user agent missing)';


### PR DESCRIPTION
This PR will:
- add sane defaults for session cookies so they don't have to be defined at php.ini
- replace ACAO `*` response header value with domain or subdomain of CORS_ALLOWED_DOMAIN setting, effectively blocking unwanted cross-origin requests

I've tested it on my environment, but would like to request retesting on staging.