### PR TITLE
fix trufflehog base/head comparison

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -94,12 +94,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: TruffleHog Secret Scanning
+      - name: TruffleHog Secret Scanning (Push)
+        if: github.event_name == 'push'
         uses: trufflesecurity/trufflehog@05cccb53bc9e13bc6d17997db5a6bcc3df44bf2f # main 2025-12-11
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event.before }}
+          head: ${{ github.event.after }}
+          extra_args: --only-verified
+
+      - name: TruffleHog Secret Scanning (Schedule)
+        if: github.event_name == 'schedule'
+        uses: trufflesecurity/trufflehog@05cccb53bc9e13bc6d17997db5a6bcc3df44bf2f # main 2025-12-11
+        with:
+          path: ./
           extra_args: --only-verified
 
   # Comprehensive audit - runs weekly


### PR DESCRIPTION
## Motivation

TruffleHog GitHub Action fails on push events because base and HEAD resolve to same commit when using default_branch and HEAD.

## Implementation information

Split TruffleHog step into two conditional steps:
- Push events: use github.event.before/after for proper commit range
- Schedule events: scan entire repo without base/head

## Supporting documentation

Fixes https://github.com/uprzejmiedonosze/uprzejmiedonosze/actions/runs/20430147256/job/58698882221