### PR TITLE
Account removal: implement user account deletion and data removal

### DIFF
--- a/docker/ud-account-removal.service
+++ b/docker/ud-account-removal.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Uprzejmie Donosze — remove inactive user accounts
+
+[Service]
+Type=oneshot
+User=www-data
+Group=www-data
+ExecStart=/usr/bin/php /var/www/uprzejmiedonosze.net/webapp/tools/old-users-removal.php
+StandardOutput=journal
+StandardError=journal

--- a/docker/ud-account-removal.timer
+++ b/docker/ud-account-removal.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run ud-account-removal daily at 20:15
+
+[Timer]
+OnCalendar=*-*-* 20:15:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/src/inc/dataclasses/User.php
+++ b/src/inc/dataclasses/User.php
@@ -195,6 +195,10 @@ class User extends \JSONObject{
     function confirmTerms() {
         $this->data->termsConfirmation = date(DT_FORMAT);
         $this->updated = date(DT_FORMAT);
+        if (isset($this->removalWarningSent))
+            unset($this->removalWarningSent);
+        if (isset($this->removal2ndWarningSent))
+            unset($this->removal2ndWarningSent);
     }
 
     function checkTermsConfirmation() {

--- a/src/inc/dataclasses/User.php
+++ b/src/inc/dataclasses/User.php
@@ -15,7 +15,6 @@ class User extends \JSONObject{
 
     /**
      * Creates a new User or initiate it from JSON.
-     * @SuppressWarnings(PHPMD.ErrorControlOperator)
      * @SuppressWarnings(PHPMD.Superglobals)
      */
     public function __construct($json=null, bool $dontDecode=false){
@@ -39,6 +38,10 @@ class User extends \JSONObject{
         $this->data->shareRecydywa = true;
         $this->data->sex = '?';
         $this->appsCount = 0;
+    }
+
+    public static function withJson($json, bool $dontDecode=false): User {
+        return new User($json, $dontDecode);
     }
 
     public static function withFirebaseUser($firebaseUser) {

--- a/src/inc/store/Admin.php
+++ b/src/inc/store/Admin.php
@@ -3,9 +3,10 @@
 $INACTIVITY = '-12 months';
 $WARNING = '-2 months';
 $LAST_WARNING = '-14 days';
+$BATCH_SIZE = 50;
 
 function getInactiveUsers(): array {
-    global $INACTIVITY;
+    global $INACTIVITY, $BATCH_SIZE;
     $sql = <<<SQL
         select users.value
         from users
@@ -14,40 +15,59 @@ function getInactiveUsers(): array {
                 max(json_extract(value, '$.added')) old_app
             from applications
             group by 1
-            order by 2
         ) apps on users.key = apps.email
         where apps.old_app < date('now', '$INACTIVITY')
             and json_extract(value, '$.removalWarningSent') is null
-            and json_extract(users.value, '$.updated') < date('now', '$INACTIVITY')
+            and (json_extract(users.value, '$.updated') is null
+                or json_extract(users.value, '$.updated') < date('now', '$INACTIVITY'))
             and json_extract(users.value, '$.deleted') is null
+        limit $BATCH_SIZE
     SQL;
 
     return __getUsers($sql);
 }
 
 function getWarnedUsers(): array {
-    global $INACTIVITY, $WARNING;
+    global $INACTIVITY, $WARNING, $BATCH_SIZE;
     $sql = <<<SQL
-        select value
+        select users.value
         from users
-        where json_extract(value, '$.removalWarningSent') < date('now', '$WARNING')
-            and json_extract(value, '$.updated') < date('now', '$INACTIVITY')
-            and json_extract(value, '$.removal2ndWarningSent') is null
+        join (
+            select email,
+                max(json_extract(value, '$.added')) old_app
+            from applications
+            group by 1
+        ) apps on users.key = apps.email
+        where apps.old_app < date('now', '$INACTIVITY')
+            and json_extract(users.value, '$.removalWarningSent') < date('now', '$WARNING')
+            and (json_extract(users.value, '$.updated') is null
+                or json_extract(users.value, '$.updated') < date('now', '$INACTIVITY'))
+            and json_extract(users.value, '$.removal2ndWarningSent') is null
             and json_extract(users.value, '$.deleted') is null
+        limit $BATCH_SIZE
     SQL;
 
     return __getUsers($sql);
 }
 
 function getUsersToRemove(): array {
-    global $INACTIVITY, $WARNING, $LAST_WARNING;
+    global $INACTIVITY, $WARNING, $LAST_WARNING, $BATCH_SIZE;
     $sql = <<<SQL
-        select value
+        select users.value
         from users
-        where json_extract(value, '$.removalWarningSent') < date('now', '$WARNING')
-            and json_extract(value, '$.removal2ndWarningSent') < date('now', '$LAST_WARNING')
-            and json_extract(value, '$.updated') < date('now', '$INACTIVITY')
+        join (
+            select email,
+                max(json_extract(value, '$.added')) old_app
+            from applications
+            group by 1
+        ) apps on users.key = apps.email
+        where apps.old_app < date('now', '$INACTIVITY')
+            and json_extract(users.value, '$.removalWarningSent') < date('now', '$WARNING')
+            and json_extract(users.value, '$.removal2ndWarningSent') < date('now', '$LAST_WARNING')
+            and (json_extract(users.value, '$.updated') is null
+                or json_extract(users.value, '$.updated') < date('now', '$INACTIVITY'))
             and json_extract(users.value, '$.deleted') is null
+        limit $BATCH_SIZE
     SQL;
 
     return __getUsers($sql);
@@ -62,96 +82,3 @@ function __getUsers(string $sql): array {
         fn($json) => \user\User::withJson($json, dontDecode:true));
 }
 
-
-
-function removeUser($email, $dryRun=true): string {
-    if(!isset($email)){
-        throw new \Exception("No email provided\n");
-    }
-
-    $email = \SQLite3::escapeString($email);
-    $user = \user\get($email, dontDecode:true);
-    $apps = \user\apps($user, 'allWithDrafts');
-
-    $output = "Usuwam wszystkie zgłoszenia użytkownika '$email'\n";
-    foreach($apps as $app){
-        $output .= removeApplication($app, $dryRun);
-    }
-
-    $cdn2UserFolder = __DIR__ . "/../../cdn2/{$user->number}/";
-    if(file_exists($cdn2UserFolder) && filetype($cdn2UserFolder) == 'dir'){
-        $output .= "Kasuję folder użytkownika\n";
-        if(!$dryRun){
-            $cmd = sprintf("rm -rf %s", escapeshellarg($cdn2UserFolder));
-            exec($cmd, $output);
-            unset($output);
-        }
-    }
-
-    $output .= "Zamazuję dane użytkownika w bazie\n";
-    if($dryRun){
-        return $output;
-    }
-    // adding empty user under a different key
-    $time = date(DT_FORMAT);
-    $user->data->name = 'DELETED';
-    $user->data->msisdn = 'DELETED';
-    $user->data->edelivery = 'DELETED';
-    $user->data->address = 'DELETED';
-    $user->data->email = md5($email . $time);
-    $user->emailMD5 = md5($email);
-
-    $user->deleted = $time;
-    $_SESSION['user_id'] = 'fake';
-    \user\save($user, dontDecode:true);
-
-    // removing old user
-    \store\delete('users', $email);
-
-    return $output;
-}
-
-function removeApplication($app, $dryRun): string{
-    global $STATUSES;
-    $added = (isset($app->added))? " dodane {$app->added}": "";
-    $number = (isset($app->number))? "{$app->number} ($app->id)": "($app->id)";
-    $status = $STATUSES[$app->status]->name;
-    $email = (isset($app->email))? " użytkownika {$app->email}": " użytkownika @anonim";
-    
-    $output = "Usuwam zgłoszenie numer $number [$status]$email$added\n";
-    if(isset($app->carImage)){
-        $output .= removeFile($app->carImage->url, $dryRun);
-        $output .= removeFile($app->carImage->thumb, $dryRun);
-    }
-    if(isset($app->contextImage)){
-        $output .= removeFile($app->contextImage->url, $dryRun);
-        $output .= removeFile($app->contextImage->thumb, $dryRun);
-    }
-    if(isset($app->carInfo) && isset($app->carInfo->plateImage)){
-        $output .= removeFile($app->carInfo->plateImage, $dryRun);
-    }
-
-    $output .= " zgłoszenie oraz jego pliki usunięte;\n\n";
-    if($dryRun){
-        return $output;
-    }
-    \store\delete('applications', $app->id);
-    return $output;
-}
-
-function removeFile($fileName, $dryRun){
-    $file = __DIR__ . "/../../$fileName";
-    if(!isset($file) || empty($fileName)){
-        return;
-    }
-    if(!file_exists($file)){
-        return " ! plik '$fileName' nie istnieje\n";
-    }
-    if(filetype($file) !== 'file'){
-        return " ! '$fileName' nie jest plikiem\n";
-    }
-    if(!$dryRun){
-        unlink($file);
-    }
-    return " - usuwam '$fileName'\n";
-}

--- a/src/inc/store/Admin.php
+++ b/src/inc/store/Admin.php
@@ -1,0 +1,157 @@
+<?PHP namespace admin;
+
+$INACTIVITY = '-12 months';
+$WARNING = '-2 months';
+$LAST_WARNING = '-14 days';
+
+function getInactiveUsers(): array {
+    global $INACTIVITY;
+    $sql = <<<SQL
+        select users.value
+        from users
+        join (
+            select email,
+                max(json_extract(value, '$.added')) old_app
+            from applications
+            group by 1
+            order by 2
+        ) apps on users.key = apps.email
+        where apps.old_app < date('now', '$INACTIVITY')
+            and json_extract(value, '$.removalWarningSent') is null
+            and json_extract(users.value, '$.updated') < date('now', '$INACTIVITY')
+            and json_extract(users.value, '$.deleted') is null
+    SQL;
+
+    return __getUsers($sql);
+}
+
+function getWarnedUsers(): array {
+    global $INACTIVITY, $WARNING;
+    $sql = <<<SQL
+        select value
+        from users
+        where json_extract(value, '$.removalWarningSent') < date('now', '$WARNING')
+            and json_extract(value, '$.updated') < date('now', '$INACTIVITY')
+            and json_extract(value, '$.removal2ndWarningSent') is null
+            and json_extract(users.value, '$.deleted') is null
+    SQL;
+
+    return __getUsers($sql);
+}
+
+function getUsersToRemove(): array {
+    global $INACTIVITY, $WARNING, $LAST_WARNING;
+    $sql = <<<SQL
+        select value
+        from users
+        where json_extract(value, '$.removalWarningSent') < date('now', '$WARNING')
+            and json_extract(value, '$.removal2ndWarningSent') < date('now', '$LAST_WARNING')
+            and json_extract(value, '$.updated') < date('now', '$INACTIVITY')
+            and json_extract(users.value, '$.deleted') is null
+    SQL;
+
+    return __getUsers($sql);
+}
+
+
+function __getUsers(string $sql): array {
+    $stmt = \store\prepare($sql);
+    $stmt->execute();
+
+    return $stmt->fetchAll(\PDO::FETCH_FUNC,
+        fn($json) => \user\User::withJson($json, dontDecode:true));
+}
+
+
+
+function removeUser($email, $dryRun=true): string {
+    if(!isset($email)){
+        throw new \Exception("No email provided\n");
+    }
+
+    $email = \SQLite3::escapeString($email);
+    $user = \user\get($email, dontDecode:true);
+    $apps = \user\apps($user, 'allWithDrafts');
+
+    $output = "Usuwam wszystkie zgłoszenia użytkownika '$email'\n";
+    foreach($apps as $app){
+        $output .= removeApplication($app, $dryRun);
+    }
+
+    $cdn2UserFolder = __DIR__ . "/../../cdn2/{$user->number}/";
+    if(file_exists($cdn2UserFolder) && filetype($cdn2UserFolder) == 'dir'){
+        $output .= "Kasuję folder użytkownika\n";
+        if(!$dryRun){
+            $cmd = sprintf("rm -rf %s", escapeshellarg($cdn2UserFolder));
+            exec($cmd, $output);
+            unset($output);
+        }
+    }
+
+    $output .= "Zamazuję dane użytkownika w bazie\n";
+    if($dryRun){
+        return $output;
+    }
+    // adding empty user under a different key
+    $time = date(DT_FORMAT);
+    $user->data->name = 'DELETED';
+    $user->data->msisdn = 'DELETED';
+    $user->data->edelivery = 'DELETED';
+    $user->data->address = 'DELETED';
+    $user->data->email = md5($email . $time);
+    $user->emailMD5 = md5($email);
+
+    $user->deleted = $time;
+    $_SESSION['user_id'] = 'fake';
+    \user\save($user, dontDecode:true);
+
+    // removing old user
+    \store\delete('users', $email);
+
+    return $output;
+}
+
+function removeApplication($app, $dryRun): string{
+    global $STATUSES;
+    $added = (isset($app->added))? " dodane {$app->added}": "";
+    $number = (isset($app->number))? "{$app->number} ($app->id)": "($app->id)";
+    $status = $STATUSES[$app->status]->name;
+    $email = (isset($app->email))? " użytkownika {$app->email}": " użytkownika @anonim";
+    
+    $output = "Usuwam zgłoszenie numer $number [$status]$email$added\n";
+    if(isset($app->carImage)){
+        $output .= removeFile($app->carImage->url, $dryRun);
+        $output .= removeFile($app->carImage->thumb, $dryRun);
+    }
+    if(isset($app->contextImage)){
+        $output .= removeFile($app->contextImage->url, $dryRun);
+        $output .= removeFile($app->contextImage->thumb, $dryRun);
+    }
+    if(isset($app->carInfo) && isset($app->carInfo->plateImage)){
+        $output .= removeFile($app->carInfo->plateImage, $dryRun);
+    }
+
+    $output .= " zgłoszenie oraz jego pliki usunięte;\n\n";
+    if($dryRun){
+        return $output;
+    }
+    \store\delete('applications', $app->id);
+    return $output;
+}
+
+function removeFile($fileName, $dryRun){
+    $file = __DIR__ . "/../../$fileName";
+    if(!isset($file) || empty($fileName)){
+        return;
+    }
+    if(!file_exists($file)){
+        return " ! plik '$fileName' nie istnieje\n";
+    }
+    if(filetype($file) !== 'file'){
+        return " ! '$fileName' nie jest plikiem\n";
+    }
+    if(!$dryRun){
+        unlink($file);
+    }
+    return " - usuwam '$fileName'\n";
+}

--- a/src/templates/bezpieczenstwo.html.twig
+++ b/src/templates/bezpieczenstwo.html.twig
@@ -40,7 +40,17 @@ co sprawia, że złamanie szyfrowania jest praktycznie niemożliwe.</p>
 Jeśli potrafisz złamać szyfrowanie, to poznasz np. mój adres zamieszkania. Pierwszej osobie
 która tego dokona płacę 500 zł tzw. bug-bounty. Powodzenia!</p>
 
-<h3>3. Organy ścigania będą mogły mieć wgląd wyłącznie w ściśle określonych przypadkach</h3>
+<h3>3. Dane nieaktywnych kont są automatycznie usuwane</h3>
+
+<p>Konta, które nie były używane przez ponad 12 miesięcy, są automatycznie usuwane wraz ze
+wszystkimi zgłoszeniami i zdjęciami. Przed usunięciem konta wysyłam dwa e-maile z
+wyprzedzeniem — najpierw z 2-miesięcznym, potem z 2-tygodniowym — dając czas na
+potwierdzenie regulaminu, jeśli chcesz zachować konto.</p>
+
+<p>Minimalizacja przechowywanych danych oznacza, że nawet w przypadku wycieku lub nakazu
+sądowego zakres dostępnych informacji jest ograniczony wyłącznie do aktywnych użytkowników.</p>
+
+<h3>4. Organy ścigania będą mogły mieć wgląd wyłącznie w ściśle określonych przypadkach</h3>
 
 <p>Dostęp do danych przez organy ścigania jest możliwy wyłącznie w przypadkach przewidzianych
 przez prawo, po przedstawieniu odpowiedniego nakazu sądowego. Proces ten jest ściśle

--- a/src/templates/changelog.html.twig
+++ b/src/templates/changelog.html.twig
@@ -8,6 +8,10 @@
 {% extends "base.html.twig" %}
 {% block main %}
 <h2>Historia zmian</h2>
+<h4>Czwartek, 16 kwietnia 2026</h4>
+<ul>
+    <li>Automatyczne usuwanie kont nieaktywnych przez ponad 12 miesięcy — z powiadomieniami e-mail z 2-miesięcznym i 2-tygodniowym wyprzedzeniem. Polityka prywatności i strona bezpieczeństwa uzupełnione o opis procesu.</li>
+</ul>
 <h4>Środa, 15 kwietnia 2026</h4>
 <ul>
     <li>Komenda Powiatowa Policji w Chrzanowie.</li>

--- a/src/templates/polityka-prywatnosci.html.twig
+++ b/src/templates/polityka-prywatnosci.html.twig
@@ -44,7 +44,21 @@
     losowym ciągiem znaków.</li>
 </ol>
 
-<h3 id="encryption">II. Dane gromadzone i przetwarzane przez serwis</h3>
+<h3>II. Retencja danych i usuwanie nieaktywnych kont</h3>
+<ol>
+    <li>Konta Użytkowników, które nie były aktywne przez ponad 12 miesięcy, są automatycznie
+    usuwane wraz ze wszystkimi powiązanymi zgłoszeniami i plikami (zdjęciami).</li>
+    <li>Przed usunięciem konta Administrator wysyła dwa powiadomienia e-mail: pierwsze
+    z wyprzedzeniem 2 miesięcy, drugie z wyprzedzeniem 2 tygodni. Potwierdzenie
+    aktualnego regulaminu w tym czasie wstrzymuje proces usuwania.</li>
+    <li>Usunięcie konta polega na anonimizacji danych osobowych w bazie danych oraz
+    usunięciu wszystkich zgłoszeń i plików graficznych z serwerów. Kompletne usunięcie
+    danych z kopii zapasowych i logów następuje w ciągu 14 dni od usunięcia konta.</li>
+    <li>Użytkownik może w każdej chwili samodzielnie zażądać usunięcia swojego konta,
+    kontaktując się z Administratorem pod adresem szymon@uprzejmiedonosze.net.</li>
+</ol>
+
+<h3 id="encryption">III. Dane gromadzone i przetwarzane przez serwis</h3>
     <p>Dane oznaczone ikoną <span class="encrypted"></span> są szyfrowane unikalnym kluczem
     kluczem dla każdego użytkownika. Nawet w przypadku przełamania zabezpieczeń serwera Uprzejmie
     Donoszę, włamywacz nie będzie miał możliwości odczytania tych informacji.</p>
@@ -157,7 +171,7 @@
     </ul>
 </ol>
 
-<h3>III. Pliki cookies</h3>
+<h3>IV. Pliki cookies</h3>
 <ol>
     <li>Serwis Uprzejmie Donoszę używa plików cookies. Są to niewielkie pliki tekstowe,
     wysyłane przez serwer i przechowywane przez przeglądarkę www Użytkownika.</li>
@@ -173,7 +187,7 @@
     href="http://www.allaboutcookies.org/manage-cookies">allaboutcookies.org</a></li>
 </ol>
 
-<h3>IV. Uwierzytelnianie, analityka i zgłaszanie błędów</h3>
+<h3>V. Uwierzytelnianie, analityka i zgłaszanie błędów</h3>
 <ol>
     <li>Uprzejmie Donoszę wykorzystuje:
     <ul>

--- a/src/tools/old-users-removal.php
+++ b/src/tools/old-users-removal.php
@@ -1,0 +1,143 @@
+<?PHP namespace admin;
+
+require(__DIR__ . '/../../vendor/autoload.php');
+require(__DIR__ . '/../inc/include.php');
+require(__DIR__ . '/../inc/store/Admin.php');
+
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Address;
+
+sendWarning();
+send2ndWarning();
+removeUsers();
+
+function sendWarning() {
+    $candidates = getInactiveUsers();
+
+    foreach ($candidates as $user) {
+        print("\nsendWarning" . $user->getEmail());
+        __sendWarning($user);
+    }
+}
+
+function send2ndWarning() {
+    $candidates = getWarnedUsers();
+
+    foreach ($candidates as $user) {
+        print("\nsend2ndWarning" . $user->getEmail());
+        __send2ndWarning($user);
+    }
+}
+
+function removeUsers() {
+    $users = getUsersToRemove();
+
+    foreach ($users as $user) {
+        print("\nremoveUsers" . $user->getEmail());
+        __remove($user);
+    }
+
+
+}
+
+function __sendWarning(\user\User $user) {
+    $subject = "Twoje konto w Uprzejmie Donoszę zostanie usunięte po 2 latach nieaktywności";
+    $text = "
+Cześć,
+
+Twoje ostatnie zgłoszenie nieprawidłowego parkowania ma ponad dwa lata. Nie chcemy przechowywać twoich danych w nieskończoność, dlatego po tak długiej nieaktywności twoje konto zostanie usunięte.
+
+Jeśli chcesz temu zapobiec musisz w przeciągu najbliższego miesiąca potwierdzić aktualny regulamin na stronie https://uprzejmiedonosze.net/register.html?update
+
+Jeśli masz obawy o bezpieczeństwo swojego konta, to przeczytaj koniecznie to jak szyfrujemy wrażliwe dane na stronie:
+
+...
+
+Szymon Nieradka
+    ";
+
+    __sendEmail($user, $subject, $text);
+    $user->removalWarningSent = date(DT_FORMAT);
+    \user\save($user, dontDecode:true);
+}
+
+
+function __send2ndWarning(\user\User $user) {
+    $dryRun = removeUser($user->getEmail(), dryRun:true);
+    $subject = "Twoje konto w Uprzejmie Donoszę zostanie usunięte za 2 tygodnie";
+    $text = "
+Cześć,
+
+Dwa miesiące temu wysłaliśmy Ci informację o usunięciu twojego konta na Uprzejmie Donoszę ze względu na długą nieaktywność. To jest ostatnie ostrzeżenie przed usunięciem konta.
+
+Jeśli chcesz temu zapobiec musisz w przeciągu najbliższych 2 tygodni potwierdzić aktualny regulamin na stronie https://uprzejmiedonosze.net/register.html?update
+
+Usunięcie konta będzie oznaczać, że:
+
+1. Na naszych serwerach nie będzie twoich danych osobowych ani szczegółów wykonanych przez Ciebie zgłoszeń (np. zdjęć).
+2. Kolejna próba zalogowania się stworzy nowe konto z czystą historią.
+
+Pełen zapis plików oraz danych jakie zostaną usunięte za dwa tygodnie znajduje się na końcu wiadomości.
+
+Szymon Nieradka
+
+Symulacja usunięcia konta:
+$dryRun
+    ";
+
+    __sendEmail($user, $subject, $text);
+    $user->removal2ndWarningSent = date(DT_FORMAT);
+    \user\save($user, dontDecode:true);
+}
+
+function __remove(\user\User $user) {
+    $removalLog = removeUser($user->getEmail(), dryRun:false);
+
+    $subject = "Twoje konto w Uprzejmie Donoszę zostało usunięte";
+    $text = "
+Cześć,
+
+Dwa miesiące temu wysłaliśmy Ci informację o usunięciu twojego konta na Uprzejmie Donoszę ze względu na długą nieaktywność. Potem ostatnie ostrzeżenie. To email jest już tylko potwierdzeniem, że usunęliśmy twoje konto z serwisu. Co to oznacza?
+
+1. Na naszych serwerach nie ma twoich danych osobowych ani szczegółów wykonanych przez Ciebie zgłoszeń (np. zdjęć).
+2. Kolejna próba zalogowania się stworzy nowe konto z czystą historią.
+
+Pełen zapis plików oraz danych jakie zostały usunięte na końcu wiadomości. Kompletne usunięcie twoich danych, w tym logów, backupów oraz kopii wiadomości email nastąpi w przeciągu kolejnych dwóch tygodni (retencja danych).
+
+Szymon Nieradka
+
+$removalLog
+    ";
+
+    __sendEmail($user, $subject, $text);
+}
+
+function __sendEmail(\user\User $user, $subject, $text) {
+
+    $message = (new Email());
+    $message->from(new Address(MAILER_FROM, 'uprzejmiedonosze.net'));
+    $message->to($user->getEmail());
+
+    $message->subject($subject);
+    $message->text($text);
+
+    $message->getHeaders()->addTextHeader("v:isprod", isProd() ? 1 : 0);
+    $message->getHeaders()->addTextHeader("v:environment", environment());
+    $message->getHeaders()->addTextHeader("o:testmode", isDev());
+    $message->getHeaders()->addTextHeader("References", "removal-warning-{$user->number}@dka.email");
+    $message->getHeaders()->addTextHeader("X-Entity-Ref-ID", "removal-warning-{$user->number}");
+    $message->getHeaders()->addTextHeader('content-transfer-encoding', 'quoted-printable');
+
+    $transport = Transport::fromDsn(MAILER_DSN);
+
+    // @TODO
+    echo "\nSubject: $subject\n";
+    echo "To: {$user->getEmail()}\n";
+    echo "From: " . MAILER_FROM . "\n";
+    echo $text;
+    
+    //$mailer = new Mailer($transport);
+    //$mailer->send($message);
+}

--- a/src/tools/old-users-removal.php
+++ b/src/tools/old-users-removal.php
@@ -3,6 +3,7 @@
 require(__DIR__ . '/../../vendor/autoload.php');
 require(__DIR__ . '/../inc/include.php');
 require(__DIR__ . '/../inc/store/Admin.php');
+require_once(__DIR__ . '/common.php');
 
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Mailer;
@@ -17,7 +18,7 @@ function sendWarning() {
     $candidates = getInactiveUsers();
 
     foreach ($candidates as $user) {
-        print("\nsendWarning" . $user->getEmail());
+        print("\nsendWarning " . $user->getEmail());
         __sendWarning($user);
     }
 }
@@ -26,7 +27,7 @@ function send2ndWarning() {
     $candidates = getWarnedUsers();
 
     foreach ($candidates as $user) {
-        print("\nsend2ndWarning" . $user->getEmail());
+        print("\nsend2ndWarning " . $user->getEmail());
         __send2ndWarning($user);
     }
 }
@@ -35,28 +36,28 @@ function removeUsers() {
     $users = getUsersToRemove();
 
     foreach ($users as $user) {
-        print("\nremoveUsers" . $user->getEmail());
+        print("\nremoveUsers " . $user->getEmail());
         __remove($user);
     }
-
-
 }
 
 function __sendWarning(\user\User $user) {
-    $subject = "Twoje konto w Uprzejmie Donoszę zostanie usunięte po 2 latach nieaktywności";
-    $text = "
-Cześć,
+    $subject = "Twoje konto w Uprzejmie Donoszę zostanie usunięte z powodu nieaktywności";
+    $text = "Cześć,
 
-Twoje ostatnie zgłoszenie nieprawidłowego parkowania ma ponad dwa lata. Nie chcemy przechowywać twoich danych w nieskończoność, dlatego po tak długiej nieaktywności twoje konto zostanie usunięte.
+Twoje ostatnie zgłoszenie nieprawidłowego parkowania w aplikacji Uprzejmie Donoszę ma ponad rok. Zgodnie z naszą polityką bezpieczeństwa, konta nieaktywne przez ponad 12 miesięcy są usuwane.
 
-Jeśli chcesz temu zapobiec musisz w przeciągu najbliższego miesiąca potwierdzić aktualny regulamin na stronie https://uprzejmiedonosze.net/register.html?update
+Jeśli chcesz zachować swoje konto, potwierdź aktualny regulamin w ciągu najbliższych 2 miesięcy:
+https://uprzejmiedonosze.net/register.html?update
 
-Jeśli masz obawy o bezpieczeństwo swojego konta, to przeczytaj koniecznie to jak szyfrujemy wrażliwe dane na stronie:
+Jeśli nie podejmiesz żadnej akcji, Twoje konto zostanie trwale usunięte — wraz ze wszystkimi zgłoszeniami i zdjęciami.
 
-...
+Jeśli masz pytania dotyczące bezpieczeństwa swoich danych, zapraszam do zapoznania się z naszą polityką prywatności:
+https://uprzejmiedonosze.net/bezpieczenstwo.html
 
+Pozdrawiam,
 Szymon Nieradka
-    ";
+uprzejmiedonosze.net";
 
     __sendEmail($user, $subject, $text);
     $user->removalWarningSent = date(DT_FORMAT);
@@ -65,27 +66,21 @@ Szymon Nieradka
 
 
 function __send2ndWarning(\user\User $user) {
-    $dryRun = removeUser($user->getEmail(), dryRun:true);
-    $subject = "Twoje konto w Uprzejmie Donoszę zostanie usunięte za 2 tygodnie";
-    $text = "
-Cześć,
+    $subject = "Ostatnie ostrzeżenie — Twoje konto w Uprzejmie Donoszę zostanie usunięte za 2 tygodnie";
+    $text = "Cześć,
 
-Dwa miesiące temu wysłaliśmy Ci informację o usunięciu twojego konta na Uprzejmie Donoszę ze względu na długą nieaktywność. To jest ostatnie ostrzeżenie przed usunięciem konta.
+Dwa miesiące temu poinformowaliśmy Cię o planowanym usunięciu Twojego konta w Uprzejmie Donoszę z powodu nieaktywności. To jest ostatnie przypomnienie.
 
-Jeśli chcesz temu zapobiec musisz w przeciągu najbliższych 2 tygodni potwierdzić aktualny regulamin na stronie https://uprzejmiedonosze.net/register.html?update
+Jeśli chcesz zachować konto, potwierdź aktualny regulamin w ciągu najbliższych 2 tygodni:
+https://uprzejmiedonosze.net/register.html?update
 
-Usunięcie konta będzie oznaczać, że:
+Po usunięciu konta:
+1. Twoje dane osobowe, zgłoszenia i zdjęcia zostaną trwale usunięte z naszych serwerów.
+2. Ewentualna ponowna rejestracja utworzy nowe konto z czystą historią.
 
-1. Na naszych serwerach nie będzie twoich danych osobowych ani szczegółów wykonanych przez Ciebie zgłoszeń (np. zdjęć).
-2. Kolejna próba zalogowania się stworzy nowe konto z czystą historią.
-
-Pełen zapis plików oraz danych jakie zostaną usunięte za dwa tygodnie znajduje się na końcu wiadomości.
-
+Pozdrawiam,
 Szymon Nieradka
-
-Symulacja usunięcia konta:
-$dryRun
-    ";
+uprzejmiedonosze.net";
 
     __sendEmail($user, $subject, $text);
     $user->removal2ndWarningSent = date(DT_FORMAT);
@@ -93,23 +88,21 @@ $dryRun
 }
 
 function __remove(\user\User $user) {
-    $removalLog = removeUser($user->getEmail(), dryRun:false);
+    removeUser($user->getEmail(), dryRun:false);
 
     $subject = "Twoje konto w Uprzejmie Donoszę zostało usunięte";
-    $text = "
-Cześć,
+    $text = "Cześć,
 
-Dwa miesiące temu wysłaliśmy Ci informację o planowaniu usunięciu Twojego konta na Uprzejmie Donoszę ze względu na długą nieaktywność. Potem ostatnie ostrzeżenie. Ten email jest już tylko potwierdzeniem, że usunęliśmy już Twoje konto z serwisu. Co to oznacza?
+Zgodnie z wcześniejszymi informacjami, Twoje konto w serwisie Uprzejmie Donoszę zostało usunięte z powodu długiej nieaktywności.
 
-1. Na naszych serwerach nie ma twoich danych osobowych ani szczegółów wykonanych przez Ciebie zgłoszeń (np. zdjęć).
-2. Kolejna próba zalogowania się stworzy nowe konto z czystą historią.
+Co to oznacza:
+1. Twoje dane osobowe, zgłoszenia i zdjęcia zostały usunięte z naszych serwerów.
+2. Kompletne usunięcie danych z backupów i logów nastąpi w ciągu 14 dni (okres retencji).
+3. Jeśli chcesz, możesz założyć nowe konto logując się ponownie na uprzejmiedonosze.net.
 
-Pełen zapis plików oraz danych jakie zostały usunięte na końcu wiadomości. Kompletne usunięcie twoich danych, w tym logów, backupów oraz kopii wiadomości email nastąpi w przeciągu kolejnych dwóch tygodni (retencja danych).
-
+Pozdrawiam,
 Szymon Nieradka
-
-$removalLog
-    ";
+uprzejmiedonosze.net";
 
     __sendEmail($user, $subject, $text);
 }
@@ -130,14 +123,6 @@ function __sendEmail(\user\User $user, $subject, $text) {
     $message->getHeaders()->addTextHeader("X-Entity-Ref-ID", "removal-warning-{$user->number}");
     $message->getHeaders()->addTextHeader('content-transfer-encoding', 'quoted-printable');
 
-    $transport = Transport::fromDsn(MAILER_DSN);
-
-    // @TODO
-    echo "\nSubject: $subject\n";
-    echo "To: {$user->getEmail()}\n";
-    echo "From: " . MAILER_FROM . "\n";
-    echo $text;
-    
-    //$mailer = new Mailer($transport);
-    //$mailer->send($message);
+    $mailer = new Mailer(Transport::fromDsn(MAILER_DSN));
+    $mailer->send($message);
 }

--- a/src/tools/old-users-removal.php
+++ b/src/tools/old-users-removal.php
@@ -99,7 +99,7 @@ function __remove(\user\User $user) {
     $text = "
 Cześć,
 
-Dwa miesiące temu wysłaliśmy Ci informację o usunięciu twojego konta na Uprzejmie Donoszę ze względu na długą nieaktywność. Potem ostatnie ostrzeżenie. To email jest już tylko potwierdzeniem, że usunęliśmy twoje konto z serwisu. Co to oznacza?
+Dwa miesiące temu wysłaliśmy Ci informację o planowaniu usunięciu Twojego konta na Uprzejmie Donoszę ze względu na długą nieaktywność. Potem ostatnie ostrzeżenie. Ten email jest już tylko potwierdzeniem, że usunęliśmy już Twoje konto z serwisu. Co to oznacza?
 
 1. Na naszych serwerach nie ma twoich danych osobowych ani szczegółów wykonanych przez Ciebie zgłoszeń (np. zdjęć).
 2. Kolejna próba zalogowania się stworzy nowe konto z czystą historią.


### PR DESCRIPTION
This PR adds a full account removal flow to automatically remove unused user accounts associated personal data in accordance with our privacy/GDPR goals.

The idea is to run this daily.

At the moment the is no user-flow implemented. But it should be straightforward—my suggestion is to allow users to mark their accounts „to be removed” and allow cron to finish the job.

User-removal code was reused from a well-tested [src/tools/admin.php](https://github.com/uprzejmiedonosze/uprzejmiedonosze/blob/main/src/tools/admin.php) utility that I run manually.

I tested the flow on a local db—it words. But this localhost environment has disabled encryption. So tests on staging are required.

More importantly this flow is very sensitive so I really, really don't want to mess things up on prog (wrong emails sent, wrong account removal).

TODO:

1. Test flow
2. Test flow with encryption
3. Polish subjects and email texts
4. Add user-flow (later)
5. Rewire email sending
6. cron/schedule
7. Create alerts on job failure rate spike?
