### PR TITLE
SMMP api fallback to mail

### DIFF
--- a/src/api/config/sm.json
+++ b/src/api/config/sm.json
@@ -422,6 +422,7 @@
       "60-734 Poznań"
     ],
     "email": "sm@um.poznan.pl",
+    "api": "Poznan",
     "hint": "SM Poznań domyślnie nie wzywa świadka na przesłuchanie."
   },
   "Poznań-Jeżyce": {

--- a/src/api/config/sm.json
+++ b/src/api/config/sm.json
@@ -423,7 +423,7 @@
     ],
     "email": "sm@um.poznan.pl",
     "api": "Poznan",
-    "hint": "SM Poznań domyślnie nie wzywa świadka na przesłuchanie."
+    "hint": "SM Poznań domyślnie nie wzywa świadka na przesłuchanie oraz jako jedyna umożliwia wysłanie zgłoszeń bezpośrednio z poziomu Uprzejmie Donoszę. Integracja z SM Poznań jest możliwa dzięki wykorzystaniu platformy <b>Smart City Poznań/api</b>. W razie problemów z dostępnością platformy wysyłany jest mail.",
   },
   "Poznań-Jeżyce": {
     "parent": "Poznań"

--- a/src/api/config/sm.json
+++ b/src/api/config/sm.json
@@ -423,7 +423,7 @@
     ],
     "email": "sm@um.poznan.pl",
     "api": "Poznan",
-    "hint": "SM Poznań domyślnie nie wzywa świadka na przesłuchanie oraz jako jedyna umożliwia wysłanie zgłoszeń bezpośrednio z poziomu Uprzejmie Donoszę. Integracja z SM Poznań jest możliwa dzięki wykorzystaniu platformy <b>Smart City Poznań/api</b>. W razie problemów z dostępnością platformy wysyłany jest mail.",
+    "hint": "SM Poznań domyślnie nie wzywa świadka na przesłuchanie oraz jako jedyna umożliwia wysłanie zgłoszeń bezpośrednio z poziomu Uprzejmie Donoszę. Integracja z SM Poznań jest możliwa dzięki wykorzystaniu platformy <b>Smart City Poznań/api</b>. W razie problemów z dostępnością platformy wysyłany jest mail."
   },
   "Poznań-Jeżyce": {
     "parent": "Poznań"

--- a/src/inc/handlers/SessionApiHandler.php
+++ b/src/inc/handlers/SessionApiHandler.php
@@ -168,9 +168,13 @@ class SessionApiHandler extends AbstractHandler {
                 "status" => "redirect"
             ));
         }
-        return $this->renderJson($response, array(
+        $payload = array(
             "status" => $application->status
-        ));
+        );
+        if (isset($application->sent->fallback_message)) {
+            $payload["fallback_message"] = $application->sent->fallback_message;
+        }
+        return $this->renderJson($response, $payload);
     }
 
     /**

--- a/src/inc/integrations/CityAPI.php
+++ b/src/inc/integrations/CityAPI.php
@@ -63,19 +63,35 @@ abstract class CityAPI {
             . "--header 'Authorization: Basic c3p5bW9uQG5pZXJhZGthLm5ldDplaUYmb29xdWVlN0Y=' "
             . "--header 'Content-Type: multipart/form-data' "
             . "--max-time 30 "
+            . "--write-out '\nHTTPSTATUS:%{http_code}' "
             . "--form 'json={$json}' "
             . '--form uz_file=@\\"' . $contextImage . '\\" '
             . '--form uz_file_0=@\\"' . $carImage . '\\" '
             . $thirdImageForm;
         
-        $response = exec("$curl 2>&1", $retArr, $retVal);
+        exec("$curl 2>&1", $retArr, $retVal);
+        $rawOutput = implode("\n", $retArr);
+        $httpStatus = null;
+        $response = $rawOutput;
+        if (str_contains($rawOutput, 'HTTPSTATUS:')) {
+            [$response, $statusPart] = explode('HTTPSTATUS:', $rawOutput, 2);
+            $httpStatus = (int) trim($statusPart);
+            $response = rtrim($response);
+        }
+
+        $application->sent->curl_http_status = $httpStatus;
+        $application->sent->curl_raw = $response;
 
         if($retVal !== 0){
             $error = "Błąd komunikacji z API {$application->address->city}: retVal=$retVal, response=$response";
         }
 
+        if(!is_null($httpStatus) && $httpStatus >= 400){
+            $error = "Błąd komunikacji z API {$application->address->city}: http_status=$httpStatus, response=$response";
+        }
+
         $json = json_decode($response, true);
-        if(!json_last_error() === JSON_ERROR_NONE){
+        if(json_last_error() !== JSON_ERROR_NONE){
             $error = "Błąd komunikacji z API {$application->address->city}: json_last_error=" . json_last_error_msg();
         }
 

--- a/src/inc/integrations/CityAPI.php
+++ b/src/inc/integrations/CityAPI.php
@@ -62,7 +62,7 @@ abstract class CityAPI {
         $curl = "curl -s --location --request POST '$url' "
             . "--header 'Authorization: Basic c3p5bW9uQG5pZXJhZGthLm5ldDplaUYmb29xdWVlN0Y=' "
             . "--header 'Content-Type: multipart/form-data' "
-            . "--max-time 30 "
+            . "--max-time 25 "
             . "--write-out '\nHTTPSTATUS:%{http_code}' "
             . "--form 'json={$json}' "
             . '--form uz_file=@\\"' . $contextImage . '\\" '
@@ -83,7 +83,11 @@ abstract class CityAPI {
         $application->sent->curl_raw = $response;
 
         if($retVal !== 0){
-            $error = "Błąd komunikacji z API {$application->address->city}: retVal=$retVal, response=$response";
+            if ($retVal === 28) {
+                $error = "Błąd komunikacji z API {$application->address->city}: timeout";
+            } else {
+                $error = "Błąd komunikacji z API {$application->address->city}: retVal=$retVal, response=$response";
+            }
         }
 
         if(!is_null($httpStatus) && $httpStatus >= 400){

--- a/src/inc/integrations/Poznan.php
+++ b/src/inc/integrations/Poznan.php
@@ -8,7 +8,7 @@ use app\Application;
 class Poznan extends CityAPI {
     /*
      * FixMyCity (Poznań) delivery:
-     * - Best-effort API first; if it fails, we fall back to email to avoid losing reports.
+     * - Best-effort API first; if it fails, we fall back to email.
      */
     private function apiUrl(): string {
         if (isProd()) {
@@ -46,8 +46,6 @@ class Poznan extends CityAPI {
             $application->setStatus('confirmed-waiting');
             $application->sent = new JSONObject();
 
-            logger("SMMP_DEBUG delivery_start appId={$application->id} number={$application->number} method=POST url={$url}", true);
-
             try {
                 $output = parent::curlShellSend($url, $data, $application);
 
@@ -68,18 +66,13 @@ class Poznan extends CityAPI {
                 $application->sent->method = "Poznan";
 
                 \app\save($application);
-
-                logger("SMMP_DEBUG delivery_method appId={$application->id} method=api", true);
             } catch (\Throwable $e) {
                 $httpStatus = $application->sent->curl_http_status ?? 'unknown';
                 $reason = $httpStatus !== 'unknown' ? "http_status={$httpStatus}" : "error=" . $e->getMessage();
-                logger("SMMP_DEBUG delivery_failure appId={$application->id} {$reason}", true);
-                logger("SMMP_DEBUG fallback_to_email appId={$application->id}", true);
+                logger("SMMP_DEBUG delivery_failure appId={$application->id} {$reason} fallback=email method=email_fallback", true);
 
                 $mail = new Mail();
                 $application = $mail->send($application);
-
-                logger("SMMP_DEBUG delivery_method appId={$application->id} method=email_fallback", true);
             }
         } finally {
             \semaphore\release($application->id, "sendPoznan");

--- a/src/inc/integrations/Poznan.php
+++ b/src/inc/integrations/Poznan.php
@@ -6,13 +6,21 @@ use app\Application;
  * @SuppressWarnings(PHPMD.MissingImport)
  */
 class Poznan extends CityAPI {
+    /*
+     * FixMyCity (Poznań) delivery:
+     * - Best-effort API first; if it fails, we fall back to email to avoid losing reports.
+     */
+    private function apiUrl(): string {
+        if (isProd()) {
+            return "https://www.poznan.pl/mim/api/submit.html?service=fixmycity";
+        }
+        return "https://www.poznan.pl/mimtest/api/submit.html?service=fixmycity";
+    }
+
     function send(Application $application){
         parent::checkApplication($application);
 
-        $url = "https://www.poznan.pl/mimtest/api/submit.html?service=fixmycity";
-        if(isProd()){
-            $url = "https://www.poznan.pl/mim/api/submit.html?service=fixmycity";
-        }
+        $url = $this->apiUrl();
         $data = array(
             'lat' => $application->address->lat,
             'lon' => $application->address->lng,
@@ -37,27 +45,42 @@ class Poznan extends CityAPI {
             $application = \app\get($application->id); // get the latest version of the application
             $application->setStatus('confirmed-waiting');
             $application->sent = new JSONObject();
-    
-            $output = parent::curlShellSend($url, $data, $application);
-    
-            if(isset($output['response']['error_msg'])){
-                $application->setStatus('sending-failed', true);
-                unset($application->sent);
+
+            logger("SMMP_DEBUG delivery_start appId={$application->id} number={$application->number} method=POST url={$url}", true);
+
+            try {
+                $output = parent::curlShellSend($url, $data, $application);
+
+                unset($application->sent->curl_raw, $application->sent->curl_http_status);
+
+                if(isset($output['response']['error_msg'])){
+                    throw new Exception($output['response']['error_msg'], 500);
+                }
+
+                $reply = "{$output['response']['msg']} (instancja: {$output['response']['instance']}, id: {$output['response']['id']})";
+
+                $application->setStatus('confirmed-sm');
+                $application->addComment($application->guessSMData()->getName(), $reply);
+                $application->sent->date = date(DT_FORMAT);
+                $application->sent->reply = $reply;
+                $application->sent->subject = $application->getEmailSubject();
+                $application->sent->to = "fixmycity";
+                $application->sent->method = "Poznan";
+
                 \app\save($application);
-                throw new Exception($output['response']['error_msg'], 500);
+
+                logger("SMMP_DEBUG delivery_method appId={$application->id} method=api", true);
+            } catch (\Throwable $e) {
+                $httpStatus = $application->sent->curl_http_status ?? 'unknown';
+                $reason = $httpStatus !== 'unknown' ? "http_status={$httpStatus}" : "error=" . $e->getMessage();
+                logger("SMMP_DEBUG delivery_failure appId={$application->id} {$reason}", true);
+                logger("SMMP_DEBUG fallback_to_email appId={$application->id}", true);
+
+                $mail = new Mail();
+                $application = $mail->send($application);
+
+                logger("SMMP_DEBUG delivery_method appId={$application->id} method=email_fallback", true);
             }
-    
-            $reply = "{$output['response']['msg']} (instancja: {$output['response']['instance']}, id: {$output['response']['id']})";
-    
-            $application->setStatus('confirmed-sm');
-            $application->addComment($application->guessSMData()->getName(), $reply);
-            $application->sent->date = date(DT_FORMAT);
-            $application->sent->reply = $reply;
-            $application->sent->subject = $application->getEmailSubject();
-            $application->sent->to = "fixmycity";
-            $application->sent->method = "Poznan";
-    
-            \app\save($application);
         } finally {
             \semaphore\release($application->id, "sendPoznan");
         }

--- a/src/inc/integrations/Poznan.php
+++ b/src/inc/integrations/Poznan.php
@@ -10,6 +10,24 @@ class Poznan extends CityAPI {
      * FixMyCity (Poznań) delivery:
      * - Best-effort API first; if it fails, we fall back to email.
      */
+    private function fallbackMessage(string $reason): string {
+        $code = null;
+        if (preg_match('/HTTP\\s*(\\d{3})/i', $reason, $matches)) {
+            $code = $matches[1];
+        }
+        if ($code) {
+            return "Z powodu problemu z API (kod {$code}) zgłoszenie wysłano e‑mailem.";
+        }
+        $lower = strtolower($reason);
+        if (str_contains($lower, 'timeout')) {
+            return "Z powodu przekroczenia czasu odpowiedzi API zgłoszenie wysłano e‑mailem.";
+        }
+        if (str_contains($lower, 'auth')) {
+            return "Z powodu problemu z uwierzytelnieniem API zgłoszenie wysłano e‑mailem.";
+        }
+        return "Z powodu problemu z API zgłoszenie wysłano e‑mailem.";
+    }
+
     private function apiUrl(): string {
         if (isProd()) {
             return "https://www.poznan.pl/mim/api/submit.html?service=fixmycity";
@@ -43,8 +61,8 @@ class Poznan extends CityAPI {
         try {
             \semaphore\acquire($application->id, "sendPoznan");
             $application = \app\get($application->id); // get the latest version of the application
-            $application->setStatus('confirmed-waiting');
             $application->sent = new JSONObject();
+            $application->setStatus('sending');
 
             try {
                 $output = parent::curlShellSend($url, $data, $application);
@@ -68,11 +86,20 @@ class Poznan extends CityAPI {
                 \app\save($application);
             } catch (\Throwable $e) {
                 $httpStatus = $application->sent->curl_http_status ?? 'unknown';
-                $reason = $httpStatus !== 'unknown' ? "http_status={$httpStatus}" : "error=" . $e->getMessage();
-                logger("SMMP_DEBUG delivery_failure appId={$application->id} {$reason} fallback=email method=email_fallback", true);
+                if ($httpStatus !== 'unknown') {
+                    $fallbackReason = "API returned HTTP " . (int)$httpStatus;
+                } else {
+                    $fallbackReason = $e->getMessage();
+                }
+                logger("SMMP_DEBUG delivery_failure appId={$application->id} reason=\"{$fallbackReason}\" fallback=email method=email", true);
 
+                $application->setStatus('confirmed', true);
                 $mail = new Mail();
                 $application = $mail->send($application);
+                if (isset($application->sent)) {
+                    $application->sent->fallback_message = $this->fallbackMessage($fallbackReason);
+                }
+                \app\save($application);
             }
         } finally {
             \semaphore\release($application->id, "sendPoznan");

--- a/src/js/lib/send.js
+++ b/src/js/lib/send.js
@@ -10,6 +10,7 @@ async function sendApplication(/** @type {string} */ appId) {
   const whatNext = document.querySelector(".whatNext")
   const afterSend = document.querySelector(".afterSend")
   const fallbackMessage = document.querySelector(".fallback-message")
+  const slowMessageDelayMs = 12000
 
   // Use getElementById to avoid issues with IDs starting with numbers
   const appElement = document.getElementById(appId)
@@ -17,10 +18,17 @@ async function sendApplication(/** @type {string} */ appId) {
   if (statusElement) statusElement.classList.add("disabled")
 
   message("Wysyłam...")
+  let slowMessageTimeoutId
+  let requestFinished = false
+  slowMessageTimeoutId = setTimeout(() => {
+    if (requestFinished) return
+    message("Wysyłka trwa dłużej niż zwykle. Proszę o chwilę cierpliwości...")
+  }, slowMessageDelayMs)
 
   try {
     const api = new Api(`/api/app/${appId}/send`)
     const msg = await api.patch()
+    requestFinished = true
     if (msg.status == 'redirect') {
       location.href = '/brak-sm.html?id=' + appId
       return
@@ -45,6 +53,7 @@ async function sendApplication(/** @type {string} */ appId) {
     // @ts-ignore
     (typeof ga == 'function') && ga("send", "event", { eventCategory: "js", eventAction: "sendViaAPI" })
   } catch (e) {
+    requestFinished = true
     error(e.message)
     if (whatNext) /** @type {HTMLElement} */ (whatNext).style.display = 'none'
     Sentry.captureException(e, {
@@ -64,6 +73,9 @@ async function sendApplication(/** @type {string} */ appId) {
       })
     throw e // Re-throw to allow caller to handle
   } finally {
+    if (slowMessageTimeoutId) {
+      clearTimeout(slowMessageTimeoutId)
+    }
     showButtons()
   }
 }

--- a/src/js/lib/send.js
+++ b/src/js/lib/send.js
@@ -9,6 +9,7 @@ import { appClicked, closeAllApps } from "../sites/my-apps";
 async function sendApplication(/** @type {string} */ appId) {
   const whatNext = document.querySelector(".whatNext")
   const afterSend = document.querySelector(".afterSend")
+  const fallbackMessage = document.querySelector(".fallback-message")
 
   // Use getElementById to avoid issues with IDs starting with numbers
   const appElement = document.getElementById(appId)
@@ -30,6 +31,12 @@ async function sendApplication(/** @type {string} */ appId) {
     if (document.querySelector(".dziekujemy")) {
       if (whatNext) /** @type {HTMLElement} */ (whatNext).style.display = 'none'
       if (afterSend) /** @type {HTMLElement} */ (afterSend).style.display = 'block'
+      if (fallbackMessage && msg?.fallback_message) {
+        fallbackMessage.textContent = msg.fallback_message
+        fallbackMessage.style.display = 'block'
+      } else if (fallbackMessage) {
+        fallbackMessage.style.display = 'none'
+      }
     }
     if (document.querySelector('.my-applications')) {
       closeAllApps()

--- a/src/templates/dziekujemy.html.twig
+++ b/src/templates/dziekujemy.html.twig
@@ -38,6 +38,7 @@ Z poważaniem
 </div>
 <div class="afterSend">
     <h4>Dziękujemy za wysłanie zgłoszenia</h4>
+    <p class="fallback-message" style="display:none;"></p>
 </div>
 {% else %}
     {% set rightButton = 'menuStart' %}

--- a/tests/Dataclasses/SMTest.php
+++ b/tests/Dataclasses/SMTest.php
@@ -12,7 +12,7 @@ class SMTest extends TestCase
         $sm = new \SM($this->getData('poznań'));
         self::assertEquals('Straż Miejska Miasta Poznania \\\\ ul. Głogowska 26 \\\\ 60-734 Poznań', $sm->getLatexAddress());
         self::assertEquals('SM Miasta Poznania', $sm->getShortName());
-        //self::assertTrue($sm->hasAPI());
+        self::assertTrue($sm->hasAPI());
         self::assertFalse($sm->isPolice());
     }
 


### PR DESCRIPTION
On 2026-01-17 direct API delivery to SMMP Poznań (FixMyCity) was removed due to severe instability (≈50% error rate).
After discussions with SZN, I decided to reintroduce the SMMP Poznań (FixMyCity) API as a best-effort channel, while keeping email as a guaranteed fallback. The goal is to benefit from fast API-based handling when available, without risking delivery failures.

After this changes UD:
- Uses SMMP Poznań API as the primary delivery method.
- Automatically falls back to email on any API error.