### PR TITLE
driving witness warning

### DIFF
--- a/src/js/lib/validation.js
+++ b/src/js/lib/validation.js
@@ -80,6 +80,23 @@ export function bindSoftCommentValidation() {
   }
 }
 
+export function bindSidewalkDrivingWitnessWarning() {
+  const witnessElement = /** @type {HTMLInputElement} */ (document.getElementById('witness'))
+  const categoryInputs = document.querySelectorAll('input[name="category"]')
+  if (!witnessElement || categoryInputs.length === 0) return
+
+  const warnIfNeeded = () => {
+    const selectedCategory = document?.querySelector('input[name="category"]:checked')?.value || '0'
+    if (selectedCategory === '18' && !witnessElement.checked) {
+      warning('<p>Wybrałeś/wybrałaś „Jazda po chodniku”. Policja często wymaga, aby zgłaszający był świadkiem tego zdarzenia.</p><a href="#statements">Zaznacz opcję „świadek momentu parkowania”</a>')
+    }
+  }
+
+  categoryInputs.forEach(input => input.addEventListener('change', warnIfNeeded))
+  witnessElement.addEventListener('change', warnIfNeeded)
+  warnIfNeeded()
+}
+
 export const checkDateTimeValue = function () {
   const datetimeInput = /** @type {HTMLInputElement} */ (document.getElementById('datetime'))
   const dt = DateTime.fromISO(datetimeInput?.value || "")

--- a/src/js/new-app/on-load.js
+++ b/src/js/new-app/on-load.js
@@ -1,6 +1,6 @@
 import { checkFile } from "./images";
 import { validateForm } from "./validate-form";
-import { bindSoftCommentValidation } from "../lib/validation";
+import { bindSoftCommentValidation, bindSidewalkDrivingWitnessWarning } from "../lib/validation";
 
 // Constants for section class names
 const THIRD_IMAGE_SECTION_CLASS = 'thirdImageSection';
@@ -33,6 +33,7 @@ export const initHandlers = (map) => {
   validateExtensions();
 
   bindSoftCommentValidation();
+  bindSidewalkDrivingWitnessWarning();
 
   // File input change handler (event delegation)
   document.addEventListener("change", function (e) {


### PR DESCRIPTION
In practice, it’s easy to forget to mark that the reporter was a witness. For reports about driving on the sidewalk, the police often expect that the person submitting the report actually witnessed the incident.

This PR adds a small, non-blocking warning to remind users about this. The intention is to avoid situations where a report is later questioned or rejected due to missing witness information.

This change is based on practical experience, but I’d like to ask others: do you see a similar approach from the police in your area, and does this seem like a **reasonable improvement? Feedback welcome.**