### PR TITLE
feat: Validate image uploads, convert PNGs to JPEGs

### DIFF
--- a/src/inc/API.php
+++ b/src/inc/API.php
@@ -179,12 +179,35 @@ function saveImgAndThumb($application, $imageBytes, $type) {
 
     $fileName     = ROOT . "$baseFileName,$type.jpg";
     $thumbName    = ROOT . "$baseFileName,$type,t.jpg";
+
+    $rawBytes = base64_decode($imageBytes);
+    $info = getimagesizefromstring($rawBytes);
+    if ($info === false) {
+        throw new Exception("Przesłany plik nie jest obrazkiem", 400);
+    }
+
+    if ($info['mime'] === 'image/png') {
+        $src = imagecreatefromstring($rawBytes);
+        if ($src === false) {
+            throw new Exception("Nie można otworzyć pliku PNG", 400);
+        }
+        $dst = imagecreatetruecolor(imagesx($src), imagesy($src));
+        imagefill($dst, 0, 0, imagecolorallocate($dst, 255, 255, 255));
+        imagecopy($dst, $src, 0, 0, 0, 0, imagesx($src), imagesy($src));
+        imagedestroy($src);
+        ob_start();
+        imagejpeg($dst, null, 92);
+        $rawBytes = ob_get_clean();
+        imagedestroy($dst);
+    } elseif ($info['mime'] !== 'image/jpeg') {
+        throw new Exception("Nieobsługiwany format obrazka: {$info['mime']}", 415);
+    }
+
     $ifp = fopen($fileName, 'wb');
     if ($ifp === false) {
         throw new Exception("Can't open $fileName for write", 500);
     }
-
-    if (fwrite($ifp, base64_decode($imageBytes)) === false) {
+    if (fwrite($ifp, $rawBytes) === false) {
         throw new Exception("Can't write to $fileName", 500);
     }
     fclose($ifp);


### PR DESCRIPTION
The JS frontend converts images to JPEG via canvas.toDataURL("image/jpeg") before upload, but nothing prevented a raw PNG (or other format) from reaching the server — either via a direct API call or a browser that falls back to PNG in
  toDataURL. This caused imagecreatefromjpeg() to fail on the thumbnail generation step, logging an error and producing a broken thumbnail.

  Changes in src/inc/API.php (saveImgAndThumb):
  - Decode the base64 payload and inspect the actual file format with getimagesizefromstring() — format is now determined from the file header, not from the client-supplied MIME type
  - PNG files are transparently converted to JPEG (white background composite, quality 92) using GD before being written to disk
  - Any other unsupported format (GIF, WebP, BMP, …) is rejected with HTTP 415
  - Fix applies to both upload paths (SessionApiHandler and the legacy REST handler) since both call saveImgAndThumb