### PR TITLE
feat: increase full-size image limit from 1200 to 1600 px

### DIFF
--- a/src/inc/API.php
+++ b/src/inc/API.php
@@ -221,6 +221,11 @@ function saveImgAndThumb($application, $imageBytes, $type) {
     }
     fclose($ifp);
 
+    $fullSize = getimagesize($fileName);
+    if ($fullSize[0] > 1600 || $fullSize[1] > 1600) {
+        imagejpeg(resize_image($fileName, 1600, 1600, false), $fileName, 95);
+    }
+
     if (!imagejpeg(resize_image($fileName, 600, 600, false), $thumbName)) {
         logger("Wasn't able to write $fileName as thumb to $thumbName.", true);
     }

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -176,8 +176,8 @@ function resizeImage(imgToResize) {
   const canvas = document.createElement("canvas");
   const context = canvas.getContext("2d");
 
-  const MAX_WIDTH = 1200;
-  const MAX_HEIGHT = 1200;
+  const MAX_WIDTH = 1600;
+  const MAX_HEIGHT = 1600;
   let canvasWidth = imgToResize.width;
   let canvasHeight = imgToResize.height;
 


### PR DESCRIPTION
JS resizes to max 1600×1600 before upload. PHP now also caps to 1600×1600 server-side in case a file arrives larger than expected (e.g. manual upload).

