### PR TITLE
fix: re-encode uploaded images at quality 85 to cap file size

### DIFF
--- a/src/inc/API.php
+++ b/src/inc/API.php
@@ -200,26 +200,23 @@ function saveImgAndThumb($application, $imageBytes, $type) {
         if ($src === false) {
             throw new Exception("Nie można otworzyć pliku PNG", 400);
         }
-        $dst = imagecreatetruecolor(imagesx($src), imagesy($src));
-        imagefill($dst, 0, 0, imagecolorallocate($dst, 255, 255, 255));
-        imagecopy($dst, $src, 0, 0, 0, 0, imagesx($src), imagesy($src));
+        $img = imagecreatetruecolor(imagesx($src), imagesy($src));
+        imagefill($img, 0, 0, imagecolorallocate($img, 255, 255, 255));
+        imagecopy($img, $src, 0, 0, 0, 0, imagesx($src), imagesy($src));
         imagedestroy($src);
-        ob_start();
-        imagejpeg($dst, null, 92);
-        $rawBytes = ob_get_clean();
-        imagedestroy($dst);
-    } elseif ($info['mime'] !== 'image/jpeg') {
+    } elseif ($info['mime'] === 'image/jpeg') {
+        $img = imagecreatefromstring($rawBytes);
+        if ($img === false) {
+            throw new Exception("Nie można otworzyć pliku JPEG", 400);
+        }
+    } else {
         throw new Exception("Nieobsługiwany format obrazka: {$info['mime']}", 415);
     }
 
-    $ifp = fopen($fileName, 'wb');
-    if ($ifp === false) {
-        throw new Exception("Can't open $fileName for write", 500);
-    }
-    if (fwrite($ifp, $rawBytes) === false) {
+    if (!imagejpeg($img, $fileName, 85)) {
         throw new Exception("Can't write to $fileName", 500);
     }
-    fclose($ifp);
+    imagedestroy($img);
 
     $fullSize = getimagesize($fileName);
     if ($fullSize[0] > 1600 || $fullSize[1] > 1600) {

--- a/src/templates/changelog.html.twig
+++ b/src/templates/changelog.html.twig
@@ -10,7 +10,9 @@
 <h2>Historia zmian</h2>
 <h4>Niedziela, 19 kwietnia 2026</h4>
 <ul>
+    <li>Zmiana rozdzielczości zdjęć z 1200px na 1600px.</li>
     <li>Naprawa błędu przy generowaniu wersji pikselowanej zdjęcia, gdy plik źródłowy jest uszkodzony lub niedostępny.</li>
+    <li>Naprawa błędu powodującego, że przesłane zdjęcia mogły przekraczać 1 MB — zdjęcia są teraz re-enkodowane z kontrolowaną jakością przy zapisie.</li>
 </ul>
 <h4>Czwartek, 16 kwietnia 2026</h4>
 <ul>


### PR DESCRIPTION
Previously JPEG files were written as-is, so size depended entirely on the mobile encoder's quality setting — complex scenes could exceed 1MB and get rejected by the Poznań API. PNG conversion also now goes through the same imagejpeg path instead of ob_start/ob_get_clean.

Fixes UD-PHP-K5 and #24 