### PR TITLE
Fix HEIC upload for iOS 18+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,10 @@ dev:
 emulator-ui: ## Open Firebase emulator UI in browser
 	@open http://localhost:4000
 
+.PHONY: mailpit-ui
+mailpit-ui: ## Open Mailpit inbox in browser
+	@open http://localhost:8025
+
 # ── Help ──────────────────────────────────────────────────────────────────────
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ staging: ## Sync code to staging server and rebuild Docker containers
 dev:
 	@docker compose \
         -f services/compose.yml \
-        --env-file services/.env.dev \
+        $(if $(wildcard services/.env.dev),--env-file services/.env.dev,) \
         -p $@ \
         --profile $@ \
         up --build

--- a/README.md
+++ b/README.md
@@ -24,19 +24,18 @@ git clone git@github.com:uprzejmiedonosze/uprzejmiedonosze.git
 cd uprzejmiedonosze
 ```
 
-## Local secrets setup
+## Local config
 
-Dev defaults (crypto keys, mail sender, Mailpit DSN, etc.) live in **`config.dev.php`** at the repo root — loaded automatically in Docker dev.
+**`config.dev.php`** (repo root, committed) is the dev bootstrap: fixture crypto keys
+(matching `services/devroot/db/store.sqlite`), Mailpit/mail defaults, and API placeholders.
+After clone, `make dev` is enough — no extra setup required.
 
-Create `services/.env.dev` (gitignored) only for overrides or extra secrets not in `config.dev.php`:
+Docker mounts this file into the webapp. Constants from the file take precedence; Docker env
+vars (from optional `services/.env.dev`) only apply to settings **not** already defined there.
+
+Optional **`services/.env.dev`** (gitignored) — only if you need real third-party tokens, e.g.:
 
 ```bash
-# Mandatory for encryption / sessions (if not in config.dev.php)
-CRYPTO_KEY=...
-CRYPTO_IV=...
-CRYPTO_TAG=...
-
-# Firebase, Maps, ALPR, etc. (optional — app runs without them)
 MAPBOX_API_TOKEN=...
 GOOGLE_MAPS_API_TOKEN=...
 # ... see AGENTS.md for the full list
@@ -54,7 +53,7 @@ If you need a real Firebase project (for staging/prod), see the maintainer.
 
 The dev profile also starts **Mailpit** — outgoing mail is captured locally instead of hitting Mailgun. After sending a report, open the inbox at `http://localhost:8025` to preview the message body and PDF/ZIP attachments.
 
-Configured via `MAILER_DSN` in `config.dev.php` (`smtp://mailpit:1025`). Without a DSN, dev keeps the old dry-run behaviour (status updates, no message captured).
+Configured via `MAILER_DSN` in `config.dev.php` (`smtp://mailpit:1025`). If the DSN is missing, dev falls back to dry-run (status updates, no message captured).
 
 ## Running
 
@@ -65,8 +64,10 @@ make dev
 This is equivalent to:
 
 ```bash
-docker compose -f services/compose.yml --env-file services/.env.dev -p dev --profile dev up --build
+docker compose -f services/compose.yml -p dev --profile dev up --build
 ```
+
+(`services/.env.dev` is optional — see [Local config](#local-config).)
 
 The first run takes a few minutes (builds Docker images, compiles CSS/JS). Subsequent runs are fast thanks to Docker layer cache.
 
@@ -114,7 +115,7 @@ make test
 ```
 services/
 ├── compose.yml              # All Docker services (profiles: dev / staging / prod)
-├── .env.dev                 # Local secrets (gitignored, create manually)
+├── .env.dev                 # Optional extra secrets (gitignored)
 ├── face-detector/           # Python face detection service
 ├── webapp/
 │   ├── Dockerfile           # builder + webapp + worker stages
@@ -127,6 +128,7 @@ services/
 
 src/                         # All source files (never edit export/ directly)
 export/                      # Built artifacts (gitignored, populated by builder)
+config.dev.php               # Committed dev bootstrap (crypto fixture, Mailpit, etc.)
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ cd uprzejmiedonosze
 
 ## Local secrets setup
 
-Create `services/.env.dev` (gitignored) with your dev credentials. Use the structure below — all values are required for full functionality, but the app will start without optional ones:
+Dev defaults (crypto keys, mail sender, Mailpit DSN, etc.) live in **`config.dev.php`** at the repo root — loaded automatically in Docker dev.
+
+Create `services/.env.dev` (gitignored) only for overrides or extra secrets not in `config.dev.php`:
 
 ```bash
-# Mandatory for encryption / sessions
+# Mandatory for encryption / sessions (if not in config.dev.php)
 CRYPTO_KEY=...
 CRYPTO_IV=...
 CRYPTO_TAG=...
 
-# Firebase, Maps, ALPR, Mail, etc. (optional — app runs without them)
+# Firebase, Maps, ALPR, etc. (optional — app runs without them)
 MAPBOX_API_TOKEN=...
 GOOGLE_MAPS_API_TOKEN=...
 # ... see AGENTS.md for the full list
@@ -47,6 +49,12 @@ Ask the maintainer for a pre-filled `services/.env.dev` if you're joining the pr
 The dev profile starts a **Firebase Auth Emulator** automatically — no real Firebase project needed for local development. The emulator UI is available at `http://localhost:4000`.
 
 If you need a real Firebase project (for staging/prod), see the maintainer.
+
+## Email preview (Mailpit)
+
+The dev profile also starts **Mailpit** — outgoing mail is captured locally instead of hitting Mailgun. After sending a report, open the inbox at `http://localhost:8025` to preview the message body and PDF/ZIP attachments.
+
+Configured via `MAILER_DSN` in `config.dev.php` (`smtp://mailpit:1025`). Without a DSN, dev keeps the old dry-run behaviour (status updates, no message captured).
 
 ## Running
 
@@ -78,6 +86,11 @@ The Firebase emulator maps all logins to the pre-filled test account `e@nieradka
 **Open Firebase emulator UI:**
 ```bash
 make emulator-ui
+```
+
+**Open Mailpit (local email inbox):**
+```bash
+make mailpit-ui
 ```
 
 **View logs:**

--- a/config.dev.php
+++ b/config.dev.php
@@ -9,6 +9,10 @@ define('OPENAI_API_KEY', 'see README.md');
 define('OPENAI_PROJECT', 'proj_SOMEID');
 
 define('MAILER_FROM', 'u@dka.email');
+define('MAILER_FROM_ALTER', 'u@dka.email');
+define('EMAIL_SENDER', 'u@dka.email');
+define('MAILER_DSN', 'smtp://mailpit:1025');
+define('MAILER_DSN_ALTER', 'smtp://mailpit:1025');
 
 define('CRYPTO_KEY', '7700bcc0327517849e966dd169791439');
 define('CRYPTO_IV', '330adc20ed7dcf8561ff4869dd434b85');

--- a/config.dev.php
+++ b/config.dev.php
@@ -1,4 +1,6 @@
 <?php
+// Dev bootstrap — committed fixture config (pairs with services/devroot/db/store.sqlite).
+// Loaded in Docker dev via compose mount; copied to export/ by watch.sh as a fallback.
 define('PLATERECOGNIZER_SECRET', 'contact author');
 define('OPEN_ALPR_SECRET_1', 'contact author');
 define('OPEN_ALPR_SECRET_2', 'contact author');

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "exifreader": "^4.36.2",
         "firebase": "^12.9.0",
         "firebaseui": "^6.1.0",
-        "heic2any": "^0.0.4",
+        "heic-to": "^1.5.2",
         "highcharts": "^11.4.8",
         "lazysizes": "^5.3.2",
         "luxon": "^3.7.2",
@@ -6565,11 +6565,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/heic2any": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
-      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
-      "license": "MIT"
+    "node_modules/heic-to": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
+      "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
+      "license": "LGPL-3.0"
     },
     "node_modules/highcharts": {
       "version": "11.4.8",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "exifreader": "^4.36.2",
     "firebase": "^12.9.0",
     "firebaseui": "^6.1.0",
-    "heic2any": "^0.0.4",
+    "heic-to": "^1.5.2",
     "highcharts": "^11.4.8",
     "lazysizes": "^5.3.2",
     "luxon": "^3.7.2",

--- a/services/compose.yml
+++ b/services/compose.yml
@@ -50,6 +50,15 @@ services:
       - 4000:4000
     restart: always
 
+  mailpit:
+    profiles: [dev]
+    image: axllent/mailpit:latest
+    container_name: mailpit
+    ports:
+      - 8025:8025
+      - 1025:1025
+    restart: always
+
   builder:
     profiles: [dev]
     build:
@@ -94,6 +103,7 @@ services:
     working_dir: /var/www/uprzejmiedonosze.net/webapp
     volumes:
       - ../export:/var/www/uprzejmiedonosze.net/webapp
+      - ../config.dev.php:/var/www/uprzejmiedonosze.net/webapp/config.dev.php:ro
       - ./devroot/db:/var/www/uprzejmiedonosze.net/db
     env_file:
       - .env.dev
@@ -101,6 +111,8 @@ services:
       builder:
         condition: service_healthy
       firebase-emulator:
+        condition: service_started
+      mailpit:
         condition: service_started
       memcached:
         condition: service_started

--- a/services/compose.yml
+++ b/services/compose.yml
@@ -1,8 +1,8 @@
 name: ${APP_ENV:-dev}
 
-# App secrets and environment-specific config — passed to all PHP-running services.
-# Staging/prod: vars come from --env-file substitution (services/.env.staging / .env.prod).
-# Dev: loaded directly into the webapp container via env_file: .env.dev.
+# App secrets and environment-specific config.
+# Staging/prod: vars from --env-file (services/.env.staging / .env.prod) via x-app-env.
+# Dev: committed config.dev.php (mounted into webapp/builder) + optional services/.env.dev for extras.
 x-app-env: &app-env
   APP_ENV: ${APP_ENV:-prod}
   SMTP_HOST: ${SMTP_HOST:-}
@@ -58,6 +58,28 @@ services:
       - 8025:8025
       - 1025:1025
     restart: always
+
+  # Relays Firebase Auth Emulator OOB links (sign-in/reset) into Mailpit, since
+  # the emulator never sends real email. Gives dev a prod-like sign-in flow:
+  # the message lands in http://localhost:8025 with a clickable link.
+  firebase-mail-bridge:
+    profiles: [dev]
+    image: python:3-alpine
+    container_name: firebase-mail-bridge
+    restart: always
+    volumes:
+      - ./firebase-mail-bridge/bridge.py:/bridge.py:ro
+    environment:
+      EMULATOR_HOST: "firebase-emulator:9099"
+      FIREBASE_PROJECT: "demo-project"
+      BRIDGE_SMTP_HOST: "mailpit"
+      BRIDGE_SMTP_PORT: "1025"
+    command: ["python", "/bridge.py"]
+    depends_on:
+      firebase-emulator:
+        condition: service_started
+      mailpit:
+        condition: service_started
 
   builder:
     profiles: [dev]
@@ -119,6 +141,7 @@ services:
       memcached:
         condition: service_started
     environment:
+      APP_ENV: dev
       APP_HOST: localhost
       APP_HTTPS: http
       FIREBASE_AUTH_EMULATOR_HOST: "firebase-emulator:9099"

--- a/services/compose.yml
+++ b/services/compose.yml
@@ -75,6 +75,7 @@ services:
       - ../tests:/build/tests:ro
       - ../tools:/build/tools:ro
       - ../export:/build/export
+      - ../config.dev.php:/build/config.dev.php:ro
       - ./webapp/watch.sh:/watch.sh:ro
     environment:
       APP_HOST: localhost
@@ -106,7 +107,8 @@ services:
       - ../config.dev.php:/var/www/uprzejmiedonosze.net/webapp/config.dev.php:ro
       - ./devroot/db:/var/www/uprzejmiedonosze.net/db
     env_file:
-      - .env.dev
+      - path: .env.dev
+        required: false
     depends_on:
       builder:
         condition: service_healthy

--- a/services/firebase-mail-bridge/bridge.py
+++ b/services/firebase-mail-bridge/bridge.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Dev-only bridge: Firebase Auth Emulator -> SMTP (Mailpit).
+
+The Auth Emulator never sends real email; it only exposes generated OOB links
+(email sign-in, password reset, verification) at its REST endpoint. This poller
+picks up each new link and relays it as a real email into Mailpit, so dev gets a
+prod-like flow: enter email -> message lands in http://localhost:8025 -> click
+the link -> FirebaseUI completes sign-in.
+
+Stdlib only (urllib + smtplib) so it runs on a bare python:*-alpine image.
+"""
+import email.utils
+import html
+import json
+import os
+import smtplib
+import sys
+import time
+import urllib.error
+import urllib.request
+from email.message import EmailMessage
+
+EMULATOR_HOST = os.environ.get("EMULATOR_HOST", "firebase-emulator:9099")
+FIREBASE_PROJECT = os.environ.get("FIREBASE_PROJECT", "demo-project")
+SMTP_HOST = os.environ.get("BRIDGE_SMTP_HOST", "mailpit")
+SMTP_PORT = int(os.environ.get("BRIDGE_SMTP_PORT", "1025"))
+MAIL_FROM = os.environ.get("BRIDGE_MAIL_FROM", "no-reply@uprzejmiedonosze.net")
+POLL_INTERVAL = float(os.environ.get("BRIDGE_POLL_INTERVAL", "2"))
+
+OOB_URL = f"http://{EMULATOR_HOST}/emulator/v1/projects/{FIREBASE_PROJECT}/oobCodes"
+
+# requestType -> (subject, lead line). Falls back to a generic entry.
+TEMPLATES = {
+    "EMAIL_SIGNIN": ("Zaloguj się do uprzejmiedonosze.net", "Kliknij, aby się zalogować:"),
+    "PASSWORD_RESET": ("Reset hasła — uprzejmiedonosze.net", "Kliknij, aby zresetować hasło:"),
+    "VERIFY_EMAIL": ("Potwierdź adres e-mail", "Kliknij, aby potwierdzić adres e-mail:"),
+}
+
+
+def log(*args):
+    print("[fb-mail-bridge]", *args, file=sys.stderr, flush=True)
+
+
+def fetch_oob_codes():
+    with urllib.request.urlopen(OOB_URL, timeout=5) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    return data.get("oobCodes", [])
+
+
+def send_email(entry):
+    to_addr = entry.get("email")
+    link = entry.get("oobLink")
+    if not to_addr or not link:
+        log("skipping entry without email/oobLink:", entry)
+        return
+
+    subject, lead = TEMPLATES.get(
+        entry.get("requestType", ""),
+        ("Wiadomość z uprzejmiedonosze.net (dev)", "Kliknij w link:"),
+    )
+
+    msg = EmailMessage()
+    msg["From"] = MAIL_FROM
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg["Date"] = email.utils.formatdate(localtime=True)
+    msg["Message-ID"] = email.utils.make_msgid(domain="uprzejmiedonosze.net")
+    msg["X-UD-OOB-Request-Type"] = entry.get("requestType", "UNKNOWN")
+
+    msg.set_content(f"{lead}\n\n{link}\n\n--\nWysłane przez firebase-mail-bridge (dev).")
+    safe_link = html.escape(link, quote=True)
+    msg.add_alternative(
+        f"""<html><body style="font-family:sans-serif">
+  <p>{html.escape(lead)}</p>
+  <p><a href="{safe_link}" style="display:inline-block;padding:10px 18px;
+     background:#1565c0;color:#fff;text-decoration:none;border-radius:4px">
+     {html.escape(subject)}</a></p>
+  <p style="font-size:12px;color:#888;word-break:break-all">{safe_link}</p>
+  <hr><p style="font-size:11px;color:#aaa">Wysłane przez firebase-mail-bridge (dev).</p>
+</body></html>""",
+        subtype="html",
+    )
+
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=10) as smtp:
+        smtp.send_message(msg)
+    log(f"relayed {entry.get('requestType')} for {to_addr} -> {SMTP_HOST}:{SMTP_PORT}")
+
+
+def main():
+    log(f"polling {OOB_URL} every {POLL_INTERVAL}s, relaying to {SMTP_HOST}:{SMTP_PORT}")
+    seen = set()
+    while True:
+        try:
+            for entry in fetch_oob_codes():
+                code = entry.get("oobCode")
+                if not code or code in seen:
+                    continue
+                seen.add(code)
+                try:
+                    send_email(entry)
+                except Exception as err:  # noqa: BLE001 - keep the poller alive
+                    log("failed to relay:", err)
+                    seen.discard(code)  # retry next tick
+        except urllib.error.URLError as err:
+            log("emulator not reachable yet:", err)
+        except Exception as err:  # noqa: BLE001
+            log("poll error:", err)
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/webapp/nginx.conf
+++ b/services/webapp/nginx.conf
@@ -35,6 +35,8 @@ http {
     server {
         listen 80;
 
+        client_max_body_size 10m;
+
         etag on;
 
         add_header X-Frame-Options "SAMEORIGIN" always;

--- a/services/webapp/watch.sh
+++ b/services/webapp/watch.sh
@@ -21,7 +21,7 @@ build_config_env() {
     printf '<?php\ndefine("HOST", "%s");\ndefine("TWIG_HASH", "%s");\ndefine("CSS_HASH", "%s");\ndefine("JS_HASH", "%s");\ndefine("HTTPS", "%s");\n' \
         "$APP_HOST" "$TWIG_HASH" "$CSS_HASH" "$JS_HASH" "$APP_HTTPS" \
         > export/config.env.php
-    [ -f config.dev.php ] && cp config.dev.php export/config.dev.php
+    [ -f config.dev.php ] && cp config.dev.php export/config.dev.php  # fallback if compose mount absent
 }
 
 build_static() {
@@ -35,7 +35,7 @@ build_static() {
     find src/api -maxdepth 1 -name '*.html' -exec cp {} export/public/api/ \;
     cp src/images-index.html export/
     [ -d src/img ] && cp -r src/img/. export/public/img/ || true
-    [ -f config.dev.php ] && cp config.dev.php export/config.dev.php
+    [ -f config.dev.php ] && cp config.dev.php export/config.dev.php  # fallback if compose mount absent
 }
 
 build_json() {

--- a/services/webapp/watch.sh
+++ b/services/webapp/watch.sh
@@ -21,6 +21,7 @@ build_config_env() {
     printf '<?php\ndefine("HOST", "%s");\ndefine("TWIG_HASH", "%s");\ndefine("CSS_HASH", "%s");\ndefine("JS_HASH", "%s");\ndefine("HTTPS", "%s");\n' \
         "$APP_HOST" "$TWIG_HASH" "$CSS_HASH" "$JS_HASH" "$APP_HTTPS" \
         > export/config.env.php
+    [ -f config.dev.php ] && cp config.dev.php export/config.dev.php
 }
 
 build_static() {

--- a/services/webapp/watch.sh
+++ b/services/webapp/watch.sh
@@ -35,6 +35,7 @@ build_static() {
     find src/api -maxdepth 1 -name '*.html' -exec cp {} export/public/api/ \;
     cp src/images-index.html export/
     [ -d src/img ] && cp -r src/img/. export/public/img/ || true
+    [ -f config.dev.php ] && cp config.dev.php export/config.dev.php
 }
 
 build_json() {

--- a/src/api/rest/index.php
+++ b/src/api/rest/index.php
@@ -320,7 +320,7 @@ $app->group('/api/rest/app', function (RouteCollectorProxy $group) { // APPLICAT
             throw new HttpException($request, "Niewspierane rozszerzenie $ext", 415);
         
         $appId = $request->getAttribute('application')->id;
-        $application = uploadImage($appId, $pictureType, $imageBytes, $dateTime, $dtFromPicture, $latLng);
+        $application = uploadImage($appId, $pictureType, base64_decode($imageBytes, true), $dateTime, $dtFromPicture, $latLng);
         unset($application->browser);
         $response->getBody()->write(json_encode($application));
         return $response;

--- a/src/inc/API.php
+++ b/src/inc/API.php
@@ -10,6 +10,11 @@ use \Exception as Exception;
 use user\User;
 use cache\Type;
 
+// Must match MAX_IMAGE_DIM / JPEG_QUALITY on the client (src/js/new-app/images.js):
+// the browser already resizes to these before upload; the server re-enforces them.
+const MAX_IMAGE_DIM = 1600;
+const JPEG_QUALITY = 85;
+
 /**
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
  */
@@ -223,14 +228,14 @@ function saveImgAndThumb($application, $imageBytes, $type) {
         throw new Exception("Nieobsługiwany format obrazka: {$info['mime']}", 415);
     }
 
-    if (!imagejpeg($img, $fileName, 95)) {
+    if (!imagejpeg($img, $fileName, JPEG_QUALITY)) {
         throw new Exception("Can't write to $fileName", 500);
     }
     imagedestroy($img);
 
     $fullSize = getimagesize($fileName);
-    if ($fullSize[0] > 1600 || $fullSize[1] > 1600) {
-        imagejpeg(resize_image($fileName, 1600, 1600, false), $fileName, 95);
+    if ($fullSize[0] > MAX_IMAGE_DIM || $fullSize[1] > MAX_IMAGE_DIM) {
+        imagejpeg(resize_image($fileName, MAX_IMAGE_DIM, MAX_IMAGE_DIM, false), $fileName, JPEG_QUALITY);
     }
 
     if (!imagejpeg(resize_image($fileName, 600, 600, false), $thumbName)) {

--- a/src/inc/API.php
+++ b/src/inc/API.php
@@ -199,7 +199,7 @@ function saveImgAndThumb($application, $imageBytes, $type) {
     $fileName     = ROOT . "$baseFileName,$type.jpg";
     $thumbName    = ROOT . "$baseFileName,$type,t.jpg";
 
-    $rawBytes = base64_decode($imageBytes);
+    $rawBytes = $imageBytes;
     $info = getimagesizefromstring($rawBytes);
     if ($info === false) {
         throw new Exception("Przesłany plik nie jest obrazkiem", 400);

--- a/src/inc/API.php
+++ b/src/inc/API.php
@@ -223,7 +223,7 @@ function saveImgAndThumb($application, $imageBytes, $type) {
         throw new Exception("Nieobsługiwany format obrazka: {$info['mime']}", 415);
     }
 
-    if (!imagejpeg($img, $fileName, 85)) {
+    if (!imagejpeg($img, $fileName, 95)) {
         throw new Exception("Can't write to $fileName", 500);
     }
     imagedestroy($img);

--- a/src/inc/config.php
+++ b/src/inc/config.php
@@ -18,47 +18,52 @@ $STOP_AGRESJI = \json\get('stop-agresji.json', 'StopAgresji');
 $LEVELS = \json\get('levels.json', 'Level');
 $BADGES = \json\get('badges.json');
 
-if (!getenv('APP_ENV') && is_file(__DIR__ . '/../config.prod.php')) {
+$_appEnv = getenv('APP_ENV');
+$_configDev = __DIR__ . '/../config.dev.php';
+if ($_appEnv !== 'prod' && $_appEnv !== 'staging' && is_file($_configDev)) {
+    require $_configDev;
+} elseif (!getenv('APP_ENV') && is_file(__DIR__ . '/../config.prod.php')) {
     // Non-Docker deployment (quickfix rsync): config.prod.php generated from .env.prod at build time
     require __DIR__ . '/../config.prod.php';
-} else {
-define('SMTP_HOST',    getenv('SMTP_HOST')    ?: '');
-define('SMTP_USER',    getenv('SMTP_USER')    ?: '');
-define('EMAIL_SENDER', getenv('EMAIL_SENDER') ?: '');
-define('SMTP_PASS',    getenv('SMTP_PASS')    ?: '');
-define('SMTP_GMAIL',   getenv('SMTP_GMAIL')   ?: '');
-
-define('PLATERECOGNIZER_SECRET', getenv('PLATERECOGNIZER_SECRET') ?: '');
-define('OPEN_ALPR_SECRET_1',     getenv('OPEN_ALPR_SECRET_1')     ?: '');
-define('OPEN_ALPR_SECRET_2',     getenv('OPEN_ALPR_SECRET_2')     ?: '');
-define('MAPBOX_API_TOKEN',       getenv('MAPBOX_API_TOKEN')       ?: '');
-define('GOOGLE_MAPS_API_TOKEN',  getenv('GOOGLE_MAPS_API_TOKEN')  ?: '');
-define('PATRONITE_TOKEN',        getenv('PATRONITE_TOKEN')        ?: '');
-
-define('MAILER_DSN',            getenv('MAILER_DSN')            ?: '');
-define('MAILER_FROM',           getenv('MAILER_FROM')           ?: '');
-define('MAILER_WEBHOOK_SECRET', getenv('MAILER_WEBHOOK_SECRET') ?: '');
-define('MAILER_DSN_ALTER',      getenv('MAILER_DSN_ALTER')      ?: '');
-define('MAILER_FROM_ALTER',     getenv('MAILER_FROM_ALTER')     ?: '');
-
-define('CRYPTO_KEY', getenv('CRYPTO_KEY') ?: '');
-define('CRYPTO_IV',  getenv('CRYPTO_IV')  ?: '');
-define('CRYPTO_TAG', getenv('CRYPTO_TAG') ?: '');
-
-define('OPENAI_API_KEY',  getenv('OPENAI_API_KEY')  ?: '');
-define('GOOGLE_API_KEY',  getenv('GOOGLE_API_KEY')  ?: '');
-define('OPENAI_PROJECT',  getenv('OPENAI_PROJECT')  ?: '');
-
-define('MATOMO_SITE_ID',     (int)(getenv('MATOMO_SITE_ID') ?: 1));
-define('BACKEND_API_KEY',    getenv('BACKEND_API_KEY')    ?: '');
-define('CORS_ALLOWED_DOMAIN', getenv('CORS_ALLOWED_DOMAIN') ?: '');
-
-define('S3_KEY',      getenv('S3_KEY')      ?: '');
-define('S3_SECRET',   getenv('S3_SECRET')   ?: '');
-define('S3_BUCKET',   getenv('S3_BUCKET')   ?: '');
-define('S3_ENDPOINT', getenv('S3_ENDPOINT') ?: '');
-define('S3_REGION',   getenv('S3_REGION')   ?: '');
 }
+
+if (!defined('SMTP_HOST'))    define('SMTP_HOST',    getenv('SMTP_HOST')    ?: '');
+if (!defined('SMTP_USER'))    define('SMTP_USER',    getenv('SMTP_USER')    ?: '');
+if (!defined('EMAIL_SENDER')) define('EMAIL_SENDER', getenv('EMAIL_SENDER') ?: '');
+if (!defined('SMTP_PASS'))    define('SMTP_PASS',    getenv('SMTP_PASS')    ?: '');
+if (!defined('SMTP_GMAIL'))   define('SMTP_GMAIL',   getenv('SMTP_GMAIL')   ?: '');
+
+if (!defined('PLATERECOGNIZER_SECRET')) define('PLATERECOGNIZER_SECRET', getenv('PLATERECOGNIZER_SECRET') ?: '');
+if (!defined('OPEN_ALPR_SECRET_1'))     define('OPEN_ALPR_SECRET_1',     getenv('OPEN_ALPR_SECRET_1')     ?: '');
+if (!defined('OPEN_ALPR_SECRET_2'))     define('OPEN_ALPR_SECRET_2',     getenv('OPEN_ALPR_SECRET_2')     ?: '');
+if (!defined('MAPBOX_API_TOKEN'))       define('MAPBOX_API_TOKEN',       getenv('MAPBOX_API_TOKEN')       ?: '');
+if (!defined('GOOGLE_MAPS_API_TOKEN'))  define('GOOGLE_MAPS_API_TOKEN',  getenv('GOOGLE_MAPS_API_TOKEN')  ?: '');
+if (!defined('PATRONITE_TOKEN'))        define('PATRONITE_TOKEN',        getenv('PATRONITE_TOKEN')        ?: '');
+
+if (!defined('MAILER_DSN'))            define('MAILER_DSN',            getenv('MAILER_DSN')            ?: '');
+if (!defined('MAILER_FROM'))           define('MAILER_FROM',           getenv('MAILER_FROM')           ?: '');
+if (!defined('MAILER_WEBHOOK_SECRET')) define('MAILER_WEBHOOK_SECRET', getenv('MAILER_WEBHOOK_SECRET') ?: '');
+if (!defined('MAILER_DSN_ALTER'))      define('MAILER_DSN_ALTER',      getenv('MAILER_DSN_ALTER')      ?: '');
+if (!defined('MAILER_FROM_ALTER'))     define('MAILER_FROM_ALTER',     getenv('MAILER_FROM_ALTER')     ?: '');
+
+if (!defined('CRYPTO_KEY')) define('CRYPTO_KEY', getenv('CRYPTO_KEY') ?: '');
+if (!defined('CRYPTO_IV'))  define('CRYPTO_IV',  getenv('CRYPTO_IV')  ?: '');
+if (!defined('CRYPTO_TAG')) define('CRYPTO_TAG', getenv('CRYPTO_TAG') ?: '');
+
+if (!defined('OPENAI_API_KEY')) define('OPENAI_API_KEY', getenv('OPENAI_API_KEY') ?: '');
+if (!defined('GOOGLE_API_KEY')) define('GOOGLE_API_KEY', getenv('GOOGLE_API_KEY') ?: '');
+if (!defined('OPENAI_PROJECT')) define('OPENAI_PROJECT', getenv('OPENAI_PROJECT') ?: '');
+
+if (!defined('MATOMO_SITE_ID'))     define('MATOMO_SITE_ID',     (int)(getenv('MATOMO_SITE_ID') ?: 1));
+if (!defined('BACKEND_API_KEY'))    define('BACKEND_API_KEY',    getenv('BACKEND_API_KEY')    ?: '');
+if (!defined('CORS_ALLOWED_DOMAIN')) define('CORS_ALLOWED_DOMAIN', getenv('CORS_ALLOWED_DOMAIN') ?: '');
+
+if (!defined('S3_KEY'))      define('S3_KEY',      getenv('S3_KEY')      ?: '');
+if (!defined('S3_SECRET'))   define('S3_SECRET',   getenv('S3_SECRET')   ?: '');
+if (!defined('S3_BUCKET'))   define('S3_BUCKET',   getenv('S3_BUCKET')   ?: '');
+if (!defined('S3_ENDPOINT')) define('S3_ENDPOINT', getenv('S3_ENDPOINT') ?: '');
+if (!defined('S3_REGION'))   define('S3_REGION',   getenv('S3_REGION')   ?: '');
+unset($_appEnv, $_configDev);
 
 $_appHost = getenv('APP_HOST');
 if ($_appHost) {

--- a/src/inc/config.php
+++ b/src/inc/config.php
@@ -20,7 +20,10 @@ $BADGES = \json\get('badges.json');
 
 $_appEnv = getenv('APP_ENV');
 $_configDev = __DIR__ . '/../config.dev.php';
-if ($_appEnv !== 'prod' && $_appEnv !== 'staging' && is_file($_configDev)) {
+// Dev bootstrap: config.dev.php defines fixture keys, Mailpit DSN, etc.
+// getenv() below only fills constants the file did not set (cannot override defines).
+// Opt-in on APP_ENV=dev only — an unset APP_ENV must never pull in dev config.
+if ($_appEnv === 'dev' && is_file($_configDev)) {
     require $_configDev;
 } elseif (!getenv('APP_ENV') && is_file(__DIR__ . '/../config.prod.php')) {
     // Non-Docker deployment (quickfix rsync): config.prod.php generated from .env.prod at build time

--- a/src/inc/handlers/SessionApiHandler.php
+++ b/src/inc/handlers/SessionApiHandler.php
@@ -11,8 +11,8 @@ use Slim\Exception\HttpNotFoundException;
 
 class SessionApiHandler extends AbstractHandler {
 
-    /** Client caps uploads at 1600×1600 JPEG; 2MB covers Q0.95 at that size. */
-    private const MAX_IMAGE_UPLOAD_BYTES = 2_097_152;
+    /** Hard limit: client caps uploads at 1600×1600 JPEG Q0.85, which stays under 1MB. */
+    private const MAX_IMAGE_UPLOAD_BYTES = 1_048_576;
 
     private function checkEditable(Request $request, Application $app) {
         if (!$app->isEditable())
@@ -137,13 +137,14 @@ class SessionApiHandler extends AbstractHandler {
         if ($upload->getError() !== UPLOAD_ERR_OK) {
             throw new Exception("Błąd przesyłania pliku (kod {$upload->getError()})", 400);
         }
+        $tooLarge = "Zbyt duże zdjęcie (>" . (self::MAX_IMAGE_UPLOAD_BYTES >> 20) . "MB)";
         // Reject by declared size before buffering the stream into memory.
         if ($upload->getSize() > self::MAX_IMAGE_UPLOAD_BYTES) {
-            throw new Exception("Zbyt duże zdjęcie (>2MB)", 400);
+            throw new Exception($tooLarge, 400);
         }
         $imageBytes = $upload->getStream()->getContents();
         if (strlen($imageBytes) > self::MAX_IMAGE_UPLOAD_BYTES) {
-            throw new Exception("Zbyt duże zdjęcie (>2MB)", 400);
+            throw new Exception($tooLarge, 400);
         }
 
         $pictureType = $this->getParam($params, 'pictureType');

--- a/src/inc/handlers/SessionApiHandler.php
+++ b/src/inc/handlers/SessionApiHandler.php
@@ -137,6 +137,10 @@ class SessionApiHandler extends AbstractHandler {
         if ($upload->getError() !== UPLOAD_ERR_OK) {
             throw new Exception("Błąd przesyłania pliku (kod {$upload->getError()})", 400);
         }
+        // Reject by declared size before buffering the stream into memory.
+        if ($upload->getSize() > self::MAX_IMAGE_UPLOAD_BYTES) {
+            throw new Exception("Zbyt duże zdjęcie (>2MB)", 400);
+        }
         $imageBytes = $upload->getStream()->getContents();
         if (strlen($imageBytes) > self::MAX_IMAGE_UPLOAD_BYTES) {
             throw new Exception("Zbyt duże zdjęcie (>2MB)", 400);

--- a/src/inc/handlers/SessionApiHandler.php
+++ b/src/inc/handlers/SessionApiHandler.php
@@ -124,8 +124,21 @@ class SessionApiHandler extends AbstractHandler {
     public function image(Request $request, Response $response, $args): Response {
         $appId = $args['appId'];
         $params = (array)$request->getParsedBody();
+        $uploadedFiles = $request->getUploadedFiles();
 
-        $imageBytes = explode( ',', $this->getParam($params, 'image_data'))[1];
+        if (isset($uploadedFiles['image'])) {
+            $upload = $uploadedFiles['image'];
+            if ($upload->getError() !== UPLOAD_ERR_OK) {
+                throw new Exception("Błąd przesyłania pliku (kod {$upload->getError()})", 400);
+            }
+            $imageBytes = $upload->getStream()->getContents();
+        } else {
+            $imageBytes = base64_decode(explode(',', $this->getParam($params, 'image_data'))[1], true);
+            if ($imageBytes === false) {
+                throw new Exception("Nieprawidłowe dane obrazka", 400);
+            }
+        }
+
         $pictureType = $this->getParam($params, 'pictureType');
 
         $dateTime = isset($params['dateTime']) ? $params['dateTime'] : null;

--- a/src/inc/handlers/SessionApiHandler.php
+++ b/src/inc/handlers/SessionApiHandler.php
@@ -11,6 +11,9 @@ use Slim\Exception\HttpNotFoundException;
 
 class SessionApiHandler extends AbstractHandler {
 
+    /** Client caps uploads at 1600×1600 JPEG; 2MB covers Q0.95 at that size. */
+    private const MAX_IMAGE_UPLOAD_BYTES = 2_097_152;
+
     private function checkEditable(Request $request, Application $app) {
         if (!$app->isEditable())
             throw new HttpForbiddenException($request, "Zgłoszenie {$app->id} nie może być edytowane");
@@ -126,17 +129,17 @@ class SessionApiHandler extends AbstractHandler {
         $params = (array)$request->getParsedBody();
         $uploadedFiles = $request->getUploadedFiles();
 
-        if (isset($uploadedFiles['image'])) {
-            $upload = $uploadedFiles['image'];
-            if ($upload->getError() !== UPLOAD_ERR_OK) {
-                throw new Exception("Błąd przesyłania pliku (kod {$upload->getError()})", 400);
-            }
-            $imageBytes = $upload->getStream()->getContents();
-        } else {
-            $imageBytes = base64_decode(explode(',', $this->getParam($params, 'image_data'))[1], true);
-            if ($imageBytes === false) {
-                throw new Exception("Nieprawidłowe dane obrazka", 400);
-            }
+        if (!isset($uploadedFiles['image'])) {
+            throw new Exception("Brak pliku obrazka", 400);
+        }
+
+        $upload = $uploadedFiles['image'];
+        if ($upload->getError() !== UPLOAD_ERR_OK) {
+            throw new Exception("Błąd przesyłania pliku (kod {$upload->getError()})", 400);
+        }
+        $imageBytes = $upload->getStream()->getContents();
+        if (strlen($imageBytes) > self::MAX_IMAGE_UPLOAD_BYTES) {
+            throw new Exception("Zbyt duże zdjęcie (>2MB)", 400);
         }
 
         $pictureType = $this->getParam($params, 'pictureType');

--- a/src/inc/integrations/Mail.php
+++ b/src/inc/integrations/Mail.php
@@ -28,10 +28,6 @@ class Mail extends CityAPI {
             $to = $application->guessSMData()->email;
         }
 
-        $transport = Transport::fromDsn(SMTP_GMAIL . '://' . SMTP_USER . ':' . rawurlencode(SMTP_PASS) . '@' . SMTP_HOST);
-        
-        $mailer = new Mailer($transport);
-
         $subject = $application->getEmailSubject();
 
         $message = (new Email());
@@ -75,8 +71,16 @@ class Mail extends CityAPI {
             [$fileatt, $fileattname] = \app\toZip($application);
             $message->attachFromPath($fileatt, $fileattname);
 
-            if (!isDev())
+            $dryRun = isDev() && !MAILER_DSN;
+            if (!$dryRun) {
+                if (isDev()) {
+                    $transport = Transport::fromDsn(MAILER_DSN);
+                } else {
+                    $transport = Transport::fromDsn(SMTP_GMAIL . '://' . SMTP_USER . ':' . rawurlencode(SMTP_PASS) . '@' . SMTP_HOST);
+                }
+                $mailer = new Mailer($transport);
                 $mailer->send($message);
+            }
 
         } catch (TransportExceptionInterface $error) {
             $application->setStatus('sending-failed', true);

--- a/src/inc/integrations/MailGun.php
+++ b/src/inc/integrations/MailGun.php
@@ -82,16 +82,16 @@ class MailGun extends CityAPI {
             $application->sent->method = "MailGun";
             \app\save($application);
 
-            if (!isDev()) {
-                if ($this->alternate) {
-                    $transport = Transport::fromDsn(MAILER_DSN_ALTER);
-                } else {
-                    $transport = Transport::fromDsn(MAILER_DSN);
-                }
+            $dsn = $this->alternate ? MAILER_DSN_ALTER : MAILER_DSN;
+            $dryRun = isDev() && $dsn === '';
+            if (!$dryRun) {
+                $transport = Transport::fromDsn($dsn);
                 $mailer = new Mailer($transport);
                 $mailer->send($message);
-            } else {
-                logger("Sending app {$application->id} with MailGun");
+            }
+
+            if (isDev()) {
+                logger("Sending app {$application->id} with MailGun" . ($dryRun ? ' (dry-run)' : ''));
                 $application->setStatus('confirmed-waiting');
                 logger("Marking app {$application->id} as confirmed-waiting (sent)");
                 \app\save($application);

--- a/src/inc/integrations/openAlpr.php
+++ b/src/inc/integrations/openAlpr.php
@@ -87,7 +87,7 @@ function get_alpr(&$imageBytes){
 	$apiInstance = new \Swagger\Client\Api\DefaultApi();
 
     try {
-        $alpr = $apiInstance->recognizeBytes($imageBytes, OPEN_ALPR_SECRET_1,
+        $alpr = $apiInstance->recognizeBytes(base64_encode($imageBytes), OPEN_ALPR_SECRET_1,
             "eu", // country
             1, // recognize_vehicle
             "", // state

--- a/src/inc/integrations/plateRecognizer.php
+++ b/src/inc/integrations/plateRecognizer.php
@@ -56,7 +56,7 @@ function get_platerecognizer(&$imageBytes) {
     }
 
     $data = array(
-        'upload' => $imageBytes,
+        'upload' => base64_encode($imageBytes),
         'regions' => 'pl',
         'mmc' => true
     );

--- a/src/inc/store/Patronite.php
+++ b/src/inc/store/Patronite.php
@@ -38,7 +38,7 @@ enum PatronieStatus:string {
 
 
 function __get(PatronieStatus $status):array {
-    if (!defined("\\PATRONITE_TOKEN")) return [];
+    if (!defined("\\PATRONITE_TOKEN") || !\PATRONITE_TOKEN) return [];
     try {
         $result = \curl\request("https://patronite.pl/author-api/patrons/{$status->value}?with_notes=yes",
             [], "Patronite", array(

--- a/src/js/lib/Api.js
+++ b/src/js/lib/Api.js
@@ -31,6 +31,18 @@ export default class Api {
   async post(data, headers={}) {
     return await this.#postOrPatch(data, 'POST', headers)
   }
+
+  async postForm(data, headers={}) {
+    const response = await fetch(this.url, {
+      headers: {
+        'Accept': 'application/json',
+        ...headers
+      },
+      method: 'POST',
+      body: data
+    })
+    return await this.#parseResponse(response)
+  }
   
   async patch(data, headers={}) {
     return await this.#postOrPatch(data, 'PATCH', headers)

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -1,4 +1,3 @@
-import { heicTo } from "heic-to"
 import ExifReader from 'exifreader'
 
 import { setAddressByLatLng } from "../lib/geolocation";
@@ -34,9 +33,7 @@ export async function checkFile(file, id) {
     imageToResize.src = await imageToDataUri(file)
   } catch (err) {
     imageError(id, err.message || String(err))
-    Sentry.captureException(err, {
-      extra: Object.prototype.toString.call(file)
-    })
+    Sentry.captureException(err, { extra: { fileType: file.type } })
     return
   }
 
@@ -165,14 +162,13 @@ function getDateTimeFromExif(exif) {
 }
 
 async function isHeicFile(file) {
-  if (/hei/i.test(file.type)) return true
+  if (/hei(c|f)/i.test(file.type)) return true
   if (file.size < 12) return false
   const buf = await file.slice(4, 12).arrayBuffer()
   const brand = String.fromCharCode(...new Uint8Array(buf))
-  return brand.startsWith('ftyp') && /hei|mif1|msf1/.test(brand)
+  return brand.startsWith('ftyp') && /hei[cfx]|mif1|msf1/.test(brand)
 }
 
-/** Safari/WebKit decodes HEIC via the OS; libheif in heic-to can't handle all iOS 18+ variants. */
 async function heicToObjectUrl(file) {
   if (typeof createImageBitmap === 'function') {
     try {
@@ -190,12 +186,13 @@ async function heicToObjectUrl(file) {
         canvas.toBlob(b => b ? resolve(b) : reject(new Error('Conversion failed')), 'image/jpeg', 0.95)
       )
       return URL.createObjectURL(blob)
-    } catch {
-      // Chrome/Firefox or unsupported variant — fall through to WASM decoder
+    } catch (err) {
+      Sentry.captureException(err, { extra: { heicDecoder: 'native' } })
     }
   }
 
-  const blob = await heicTo({ blob: file, type: "image/jpeg", quality: 0.95 })
+  const { heicTo } = await import('heic-to')
+  const blob = await heicTo({ blob: file, type: 'image/jpeg', quality: 0.95 })
   return URL.createObjectURL(blob)
 }
 

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -266,13 +266,8 @@ async function prepareUploadBlob(file) {
     return { blob, previewUrl: URL.createObjectURL(blob) }
   }
 
-  if (/^image\/jpe?g$/i.test(file.type)) {
-    const { width, height } = await getImageDimensions(file)
-    if (fitsMaxDimensions(width, height)) {
-      return { blob: file, previewUrl: URL.createObjectURL(file) }
-    }
-  }
-
+  // Always decode non-HEIC images through the canvas so EXIF orientation is
+  // baked into the pixels — the server (GD) strips the EXIF tag on re-encode.
   const blob = await resizeBlob(file)
   return { blob, previewUrl: URL.createObjectURL(blob) }
 }

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -174,57 +174,90 @@ function loadImage(src) {
   })
 }
 
-async function getImageDimensions(fileOrBlob) {
+/**
+ * Decodes fileOrBlob with EXIF orientation applied and passes the source to fn.
+ * Prefers createImageBitmap, falling back to an <img> element (e.g. no bitmap
+ * support, or a decode error). Always closes/revokes the decoded source.
+ * @template T
+ * @param {Blob} fileOrBlob
+ * @param {(source: CanvasImageSource & { width: number, height: number }) => T | Promise<T>} fn
+ * @param {Record<string, unknown>} [sentryExtra]
+ * @returns {Promise<T>}
+ */
+async function withDecodedImage(fileOrBlob, fn, sentryExtra = {}) {
   if (typeof createImageBitmap === 'function') {
-    const bitmap = await createImageBitmap(fileOrBlob)
-    const dimensions = { width: bitmap.width, height: bitmap.height }
-    bitmap.close()
-    return dimensions
+    try {
+      const bitmap = await createImageBitmap(fileOrBlob, { imageOrientation: 'from-image' })
+      try {
+        return await fn(bitmap)
+      } finally {
+        bitmap.close()
+      }
+    } catch (err) {
+      Sentry.captureException(err, { extra: { decoder: 'bitmap', ...sentryExtra } })
+    }
   }
 
   const url = URL.createObjectURL(fileOrBlob)
   try {
     const img = await loadImage(url)
-    return { width: img.width, height: img.height }
+    return await fn(img)
   } finally {
     revokeObjectUrl(url)
   }
+}
+
+async function getImageDimensions(fileOrBlob) {
+  return withDecodedImage(
+    fileOrBlob,
+    source => ({ width: source.width, height: source.height }),
+    { op: 'dimensions' }
+  )
 }
 
 function fitsMaxDimensions(width, height) {
   return width <= MAX_IMAGE_DIM && height <= MAX_IMAGE_DIM
 }
 
+/**
+ * Converts a HEIC file to a JPEG blob. The native path also returns the decoded
+ * dimensions so the caller can skip a redundant decode; the heic-to fallback
+ * reports null dimensions (caller resolves them separately).
+ * @returns {Promise<{ blob: Blob, width: number|null, height: number|null }>}
+ */
 async function heicToJpegBlob(file) {
   if (typeof createImageBitmap === 'function') {
     try {
-      const bitmap = await createImageBitmap(file)
+      const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' })
+      const { width, height } = bitmap
       const canvas = document.createElement('canvas')
-      canvas.width = bitmap.width
-      canvas.height = bitmap.height
+      canvas.width = width
+      canvas.height = height
       const ctx = canvas.getContext('2d')
       if (!ctx) throw new Error('Canvas not supported')
       ctx.fillStyle = '#ffffff'
-      ctx.fillRect(0, 0, canvas.width, canvas.height)
+      ctx.fillRect(0, 0, width, height)
       ctx.drawImage(bitmap, 0, 0)
       bitmap.close()
-      return new Promise((resolve, reject) =>
+      const blob = await new Promise((resolve, reject) =>
         canvas.toBlob(b => b ? resolve(b) : reject(new Error('Conversion failed')), 'image/jpeg', JPEG_QUALITY)
       )
+      return { blob, width, height }
     } catch (err) {
       Sentry.captureException(err, { extra: { heicDecoder: 'native' } })
     }
   }
 
   const { heicTo } = await import('heic-to')
-  return heicTo({ blob: file, type: 'image/jpeg', quality: JPEG_QUALITY })
+  const blob = await heicTo({ blob: file, type: 'image/jpeg', quality: JPEG_QUALITY })
+  return { blob, width: null, height: null }
 }
 
 /** @returns {Promise<{ blob: Blob, previewUrl: string }>} */
 async function prepareUploadBlob(file) {
   if (await isHeicFile(file)) {
-    const jpegBlob = await heicToJpegBlob(file)
-    const { width, height } = await getImageDimensions(jpegBlob)
+    let { blob: jpegBlob, width, height } = await heicToJpegBlob(file)
+    if (width == null) ({ width, height } = await getImageDimensions(jpegBlob))
     if (fitsMaxDimensions(width, height)) {
       return { blob: jpegBlob, previewUrl: URL.createObjectURL(jpegBlob) }
     }
@@ -245,26 +278,7 @@ async function prepareUploadBlob(file) {
 }
 
 async function resizeBlob(fileOrBlob) {
-  if (typeof createImageBitmap === 'function') {
-    try {
-      const bitmap = await createImageBitmap(fileOrBlob)
-      try {
-        return await resizeSource(bitmap)
-      } finally {
-        bitmap.close()
-      }
-    } catch (err) {
-      Sentry.captureException(err, { extra: { resizeDecoder: 'bitmap' } })
-    }
-  }
-
-  const decodeUrl = URL.createObjectURL(fileOrBlob)
-  try {
-    const img = await loadImage(decodeUrl)
-    return await resizeSource(img)
-  } finally {
-    revokeObjectUrl(decodeUrl)
-  }
+  return withDecodedImage(fileOrBlob, resizeSource, { op: 'resize' })
 }
 
 /** @param {CanvasImageSource & { width: number, height: number }} source */

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -9,8 +9,9 @@ import { error } from "../lib/toast";
 import { updateRecydywa } from "./recydywa";
 import { setOcrVehicleInfo, triggerVehicleInfoEnrichment, appendAutoComment } from "./vehicle-info";
 
-// Matches saveImgAndThumb full-size re-encode quality in API.php (95).
-const JPEG_QUALITY = 0.95
+// Matches the JPEG quality used by saveImgAndThumb in API.php (85);
+// keeps a resized 1600px upload around ~1 MB.
+const JPEG_QUALITY = 0.85
 const MAX_IMAGE_DIM = 1600
 
 var uploadInProgress = 0;

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -45,11 +45,11 @@ export async function checkFile(file, id) {
   })
   imageToResize.addEventListener("load", async () => {
     try {
-      const resizedImage = resizeImage(imageToResize)
+      const resizedImage = await resizeImage(imageToResize)
       const previewElement = /** @type {HTMLImageElement} */ (document.getElementById(`${id}Preview`))
       if (previewElement) {
         previewElement.style.opacity = '0.3'
-        previewElement.src = resizedImage
+        previewElement.src = URL.createObjectURL(resizedImage)
       }
 
       if (id === "carImage") {
@@ -251,7 +251,13 @@ function resizeImage(imgToResize) {
     canvasWidth,
     canvasHeight
   );
-  return canvas.toDataURL("image/jpeg", JPEG_QUALITY);
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      blob => blob ? resolve(blob) : reject(new Error('Nie udało się przetworzyć zdjęcia')),
+      'image/jpeg',
+      JPEG_QUALITY
+    )
+  })
 }
 
 function noGeoDataInImage() {
@@ -311,22 +317,21 @@ export function repositionCarImage(vehicleBox, imageWidth, imageHeight) {
 }
 
 /**
- * @param {*} fileData
+ * @param {Blob} fileData
  * @param {'contextImage' | 'carImage' | 'thirdImage'} id
  * @param {*} imageMetadata
  */
 async function sendFile(fileData, id, imageMetadata={}) {
   const appIdElement = /** @type {HTMLInputElement} */ (document.querySelector(".new-application #applicationId"))
   const appId = appIdElement?.value
-  var data = {
-    image_data: fileData,
-    pictureType: id
-  }
+  const data = new FormData()
+  data.append('image', fileData, 'image.jpg')
+  data.append('pictureType', id)
 
   if (id == "carImage") {
-    imageMetadata.dateTime && (data.dateTime = imageMetadata.dateTime)
-    imageMetadata.dtFromPicture && (data.dtFromPicture = imageMetadata.dtFromPicture)
-    imageMetadata.latLng && (data.latLng = imageMetadata.latLng)
+    imageMetadata.dateTime && data.append('dateTime', imageMetadata.dateTime)
+    imageMetadata.dtFromPicture && data.append('dtFromPicture', 'true')
+    imageMetadata.latLng && data.append('latLng', imageMetadata.latLng)
   }
   if (id == "thirdImage") {
     showThirdImage(true)
@@ -340,7 +345,7 @@ async function sendFile(fileData, id, imageMetadata={}) {
 
   try {
     const api = new Api(`/api/app/${appId}/image`)
-    const app = await api.post(data)
+    const app = await api.postForm(data)
     if (app.carImage || app.contextImage || app.thirdImage) {
       const loader = document.querySelector(`.${id}Section .loader`)
       const preview = /** @type {HTMLImageElement} */ (document.getElementById(`${id}Preview`))

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -1,4 +1,4 @@
-import heic2any from "heic2any"
+import { heicTo } from "heic-to"
 import ExifReader from 'exifreader'
 
 import { setAddressByLatLng } from "../lib/geolocation";
@@ -30,7 +30,19 @@ export async function checkFile(file, id) {
 
   const imageToResize = document.createElement('img')
 
-  imageToResize.src = await imageToDataUri(file)
+  try {
+    imageToResize.src = await imageToDataUri(file)
+  } catch (err) {
+    imageError(id, err.message || String(err))
+    Sentry.captureException(err, {
+      extra: Object.prototype.toString.call(file)
+    })
+    return
+  }
+
+  imageToResize.addEventListener("error", () => {
+    imageError(id, 'Nie można wczytać zdjęcia')
+  })
   imageToResize.addEventListener("load", async () => {
     try {
       const resizedImage = resizeImage(imageToResize)
@@ -152,10 +164,44 @@ function getDateTimeFromExif(exif) {
   return dateTime?.description
 }
 
+async function isHeicFile(file) {
+  if (/hei/i.test(file.type)) return true
+  if (file.size < 12) return false
+  const buf = await file.slice(4, 12).arrayBuffer()
+  const brand = String.fromCharCode(...new Uint8Array(buf))
+  return brand.startsWith('ftyp') && /hei|mif1|msf1/.test(brand)
+}
+
+/** Safari/WebKit decodes HEIC via the OS; libheif in heic-to can't handle all iOS 18+ variants. */
+async function heicToObjectUrl(file) {
+  if (typeof createImageBitmap === 'function') {
+    try {
+      const bitmap = await createImageBitmap(file)
+      const canvas = document.createElement('canvas')
+      canvas.width = bitmap.width
+      canvas.height = bitmap.height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) throw new Error('Canvas not supported')
+      ctx.fillStyle = '#ffffff'
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+      ctx.drawImage(bitmap, 0, 0)
+      bitmap.close()
+      const blob = await new Promise((resolve, reject) =>
+        canvas.toBlob(b => b ? resolve(b) : reject(new Error('Conversion failed')), 'image/jpeg', 0.95)
+      )
+      return URL.createObjectURL(blob)
+    } catch {
+      // Chrome/Firefox or unsupported variant — fall through to WASM decoder
+    }
+  }
+
+  const blob = await heicTo({ blob: file, type: "image/jpeg", quality: 0.95 })
+  return URL.createObjectURL(blob)
+}
+
 async function imageToDataUri(img) {
-  if (img.type.includes('hei')) {
-    const blob = await heic2any({ blob: img, toType: "image/jpeg" })
-    return URL.createObjectURL(blob)
+  if (await isHeicFile(img)) {
+    return heicToObjectUrl(img)
   } else {
     return await pngToDataUri(img)
   }

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -9,6 +9,9 @@ import { error } from "../lib/toast";
 import { updateRecydywa } from "./recydywa";
 import { setOcrVehicleInfo, triggerVehicleInfoEnrichment, appendAutoComment } from "./vehicle-info";
 
+// Matches saveImgAndThumb full-size re-encode quality in API.php (95).
+const JPEG_QUALITY = 0.95
+
 var uploadInProgress = 0;
 
 /**
@@ -183,7 +186,7 @@ async function heicToObjectUrl(file) {
       ctx.drawImage(bitmap, 0, 0)
       bitmap.close()
       const blob = await new Promise((resolve, reject) =>
-        canvas.toBlob(b => b ? resolve(b) : reject(new Error('Conversion failed')), 'image/jpeg', 0.95)
+        canvas.toBlob(b => b ? resolve(b) : reject(new Error('Conversion failed')), 'image/jpeg', JPEG_QUALITY)
       )
       return URL.createObjectURL(blob)
     } catch (err) {
@@ -192,7 +195,7 @@ async function heicToObjectUrl(file) {
   }
 
   const { heicTo } = await import('heic-to')
-  const blob = await heicTo({ blob: file, type: 'image/jpeg', quality: 0.95 })
+  const blob = await heicTo({ blob: file, type: 'image/jpeg', quality: JPEG_QUALITY })
   return URL.createObjectURL(blob)
 }
 
@@ -248,7 +251,7 @@ function resizeImage(imgToResize) {
     canvasWidth,
     canvasHeight
   );
-  return canvas.toDataURL("image/jpeg", 0.95);
+  return canvas.toDataURL("image/jpeg", JPEG_QUALITY);
 }
 
 function noGeoDataInImage() {

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -11,6 +11,7 @@ import { setOcrVehicleInfo, triggerVehicleInfoEnrichment, appendAutoComment } fr
 
 // Matches saveImgAndThumb full-size re-encode quality in API.php (95).
 const JPEG_QUALITY = 0.95
+const MAX_IMAGE_DIM = 1600
 
 var uploadInProgress = 0;
 
@@ -30,58 +31,46 @@ export async function checkFile(file, id) {
     );
   }
 
-  const imageToResize = document.createElement('img')
-
+  let previewUrl = null
   try {
-    imageToResize.src = await imageToDataUri(file)
-  } catch (err) {
-    imageError(id, err.message || String(err))
-    Sentry.captureException(err, { extra: { fileType: file.type } })
-    return
-  }
+    const prepared = await prepareUploadBlob(file)
+    previewUrl = prepared.previewUrl
 
-  imageToResize.addEventListener("error", () => {
-    imageError(id, 'Nie można wczytać zdjęcia')
-  })
-  imageToResize.addEventListener("load", async () => {
-    try {
-      const resizedImage = await resizeImage(imageToResize)
-      const previewElement = /** @type {HTMLImageElement} */ (document.getElementById(`${id}Preview`))
-      if (previewElement) {
-        previewElement.style.opacity = '0.3'
-        previewElement.src = URL.createObjectURL(resizedImage)
-      }
-
-      if (id === "carImage") {
-        const exif = await ExifReader.load(file)
-        const [lat, lng] = readGeoDataFromExif(exif)
-        let dateTime = getDateTimeFromExif(exif)
-
-        dateTime = setDateTime(dateTime, !!dateTime)
-        if (lat) setAddressByLatLng(lat, lng, "picture")
-        else noGeoDataInImage()
-
-        const plateImage = /** @type {HTMLImageElement} */ (document.getElementById("plateImage"))
-        if (plateImage) {
-          plateImage.src = ""
-          plateImage.style.display = 'none'
-        }
-        await sendFile(resizedImage, id, {
-          dateTime,
-          dtFromPicture: !!dateTime,
-          latLng: `${lat},${lng}`
-        });
-      } else {
-        await sendFile(resizedImage, id);
-      }
-
-    } catch (err) {
-      imageError(id, err.message);
-      Sentry.captureException(err, {
-        extra: Object.prototype.toString.call(file)
-      });
+    const previewElement = /** @type {HTMLImageElement} */ (document.getElementById(`${id}Preview`))
+    if (previewElement) {
+      previewElement.style.opacity = '0.3'
+      previewElement.src = previewUrl
     }
-  })
+
+    if (id === "carImage") {
+      const exif = await ExifReader.load(file)
+      const [lat, lng] = readGeoDataFromExif(exif)
+      let dateTime = getDateTimeFromExif(exif)
+
+      dateTime = setDateTime(dateTime, !!dateTime)
+      if (lat) setAddressByLatLng(lat, lng, "picture")
+      else noGeoDataInImage()
+
+      const plateImage = /** @type {HTMLImageElement} */ (document.getElementById("plateImage"))
+      if (plateImage) {
+        plateImage.src = ""
+        plateImage.style.display = 'none'
+      }
+      await sendFile(prepared.blob, id, {
+        dateTime,
+        dtFromPicture: !!dateTime,
+        latLng: `${lat},${lng}`
+      }, previewUrl);
+    } else {
+      await sendFile(prepared.blob, id, {}, previewUrl);
+    }
+  } catch (err) {
+    revokeObjectUrl(previewUrl)
+    imageError(id, err.message || String(err));
+    Sentry.captureException(err, {
+      extra: { fileType: file.type }
+    });
+  }
 
 }
 
@@ -172,7 +161,41 @@ async function isHeicFile(file) {
   return brand.startsWith('ftyp') && /hei[cfx]|mif1|msf1/.test(brand)
 }
 
-async function heicToObjectUrl(file) {
+function revokeObjectUrl(url) {
+  if (url?.startsWith('blob:')) URL.revokeObjectURL(url)
+}
+
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = document.createElement('img')
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('Nie można wczytać zdjęcia'))
+    img.src = src
+  })
+}
+
+async function getImageDimensions(fileOrBlob) {
+  if (typeof createImageBitmap === 'function') {
+    const bitmap = await createImageBitmap(fileOrBlob)
+    const dimensions = { width: bitmap.width, height: bitmap.height }
+    bitmap.close()
+    return dimensions
+  }
+
+  const url = URL.createObjectURL(fileOrBlob)
+  try {
+    const img = await loadImage(url)
+    return { width: img.width, height: img.height }
+  } finally {
+    revokeObjectUrl(url)
+  }
+}
+
+function fitsMaxDimensions(width, height) {
+  return width <= MAX_IMAGE_DIM && height <= MAX_IMAGE_DIM
+}
+
+async function heicToJpegBlob(file) {
   if (typeof createImageBitmap === 'function') {
     try {
       const bitmap = await createImageBitmap(file)
@@ -185,59 +208,82 @@ async function heicToObjectUrl(file) {
       ctx.fillRect(0, 0, canvas.width, canvas.height)
       ctx.drawImage(bitmap, 0, 0)
       bitmap.close()
-      const blob = await new Promise((resolve, reject) =>
+      return new Promise((resolve, reject) =>
         canvas.toBlob(b => b ? resolve(b) : reject(new Error('Conversion failed')), 'image/jpeg', JPEG_QUALITY)
       )
-      return URL.createObjectURL(blob)
     } catch (err) {
       Sentry.captureException(err, { extra: { heicDecoder: 'native' } })
     }
   }
 
   const { heicTo } = await import('heic-to')
-  const blob = await heicTo({ blob: file, type: 'image/jpeg', quality: JPEG_QUALITY })
-  return URL.createObjectURL(blob)
+  return heicTo({ blob: file, type: 'image/jpeg', quality: JPEG_QUALITY })
 }
 
-async function imageToDataUri(img) {
-  if (await isHeicFile(img)) {
-    return heicToObjectUrl(img)
-  } else {
-    return await pngToDataUri(img)
+/** @returns {Promise<{ blob: Blob, previewUrl: string }>} */
+async function prepareUploadBlob(file) {
+  if (await isHeicFile(file)) {
+    const jpegBlob = await heicToJpegBlob(file)
+    const { width, height } = await getImageDimensions(jpegBlob)
+    if (fitsMaxDimensions(width, height)) {
+      return { blob: jpegBlob, previewUrl: URL.createObjectURL(jpegBlob) }
+    }
+
+    const blob = await resizeBlob(jpegBlob)
+    return { blob, previewUrl: URL.createObjectURL(blob) }
+  }
+
+  if (/^image\/jpe?g$/i.test(file.type)) {
+    const { width, height } = await getImageDimensions(file)
+    if (fitsMaxDimensions(width, height)) {
+      return { blob: file, previewUrl: URL.createObjectURL(file) }
+    }
+  }
+
+  const blob = await resizeBlob(file)
+  return { blob, previewUrl: URL.createObjectURL(blob) }
+}
+
+async function resizeBlob(fileOrBlob) {
+  if (typeof createImageBitmap === 'function') {
+    try {
+      const bitmap = await createImageBitmap(fileOrBlob)
+      try {
+        return await resizeSource(bitmap)
+      } finally {
+        bitmap.close()
+      }
+    } catch (err) {
+      Sentry.captureException(err, { extra: { resizeDecoder: 'bitmap' } })
+    }
+  }
+
+  const decodeUrl = URL.createObjectURL(fileOrBlob)
+  try {
+    const img = await loadImage(decodeUrl)
+    return await resizeSource(img)
+  } finally {
+    revokeObjectUrl(decodeUrl)
   }
 }
 
-function pngToDataUri(field) {
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-
-    reader.addEventListener("load", () => {
-      resolve(reader.result);
-    });
-
-    reader.readAsDataURL(field);
-  });
-}
-
-function resizeImage(imgToResize) {
+/** @param {CanvasImageSource & { width: number, height: number }} source */
+function resizeSource(source) {
   const canvas = document.createElement("canvas");
   const context = canvas.getContext("2d");
 
-  const MAX_WIDTH = 1600;
-  const MAX_HEIGHT = 1600;
-  let canvasWidth = imgToResize.width;
-  let canvasHeight = imgToResize.height;
+  let canvasWidth = source.width;
+  let canvasHeight = source.height;
 
-  // Add the resizing logic
   if (canvasWidth > canvasHeight) {
-    if (canvasWidth > MAX_WIDTH) {
-      canvasHeight *= MAX_WIDTH / canvasWidth;
-      canvasWidth = MAX_WIDTH;
+    if (canvasWidth > MAX_IMAGE_DIM) {
+      canvasHeight *= MAX_IMAGE_DIM / canvasWidth;
+      canvasWidth = MAX_IMAGE_DIM;
     }
   } else {
-    if (canvasHeight > MAX_HEIGHT) {
-      canvasWidth *= MAX_HEIGHT / canvasHeight;
-      canvasHeight = MAX_HEIGHT;
+    if (canvasHeight > MAX_IMAGE_DIM) {
+      canvasWidth *= MAX_IMAGE_DIM / canvasHeight;
+      canvasHeight = MAX_IMAGE_DIM;
     }
   }
 
@@ -245,7 +291,7 @@ function resizeImage(imgToResize) {
   canvas.height = canvasHeight;
 
   context?.drawImage(
-    imgToResize,
+    source,
     0,
     0,
     canvasWidth,
@@ -320,8 +366,9 @@ export function repositionCarImage(vehicleBox, imageWidth, imageHeight) {
  * @param {Blob} fileData
  * @param {'contextImage' | 'carImage' | 'thirdImage'} id
  * @param {*} imageMetadata
+ * @param {string|null} previewUrl
  */
-async function sendFile(fileData, id, imageMetadata={}) {
+async function sendFile(fileData, id, imageMetadata={}, previewUrl=null) {
   const appIdElement = /** @type {HTMLInputElement} */ (document.querySelector(".new-application #applicationId"))
   const appId = appIdElement?.value
   const data = new FormData()
@@ -397,6 +444,8 @@ async function sendFile(fileData, id, imageMetadata={}) {
     uploadFinished()
   } catch (err) {
     imageError(id, err.toString())
+  } finally {
+    revokeObjectUrl(previewUrl)
   }
 }
 

--- a/src/templates/changelog.html.twig
+++ b/src/templates/changelog.html.twig
@@ -16,6 +16,7 @@
     <li>Zmiana domyślnego odbiorcy zgłoszeń z SM na Policję (dla nowozarejestrowanych użytkowników).</li>
     <li>Wybór jednostki (Straż Miejska / Policja) nie jest już pytaniem przy rejestracji konta — zapamiętujemy go automatycznie na podstawie wyboru dokonanego przy zgłoszeniu, a nowe konta domyślnie startują ze Strażą Miejską.</li>
     <li>Skrzynki #stopagresji są teraz traktowane jako gwarantowany, ostateczny fallback przy wysyłce na Policję, a nie jako lista konkretnych komisariatów — dzięki temu więcej zgłoszeń trafia bezpośrednio do właściwego, lokalnego komisariatu.</li>
+    <li>Naprawiono błąd występujący podczas wgrywania zdjęć w formacie HEIC zrobionych na iPhone'ach z systemem iOS 18 lub nowszym.</li>
 </ul>
 <h4>Środa, 24 czerwca 2026</h4>
 <ul>

--- a/tests/API/ImageUploadTest.php
+++ b/tests/API/ImageUploadTest.php
@@ -136,13 +136,13 @@ class ImageUploadTest extends TestCase
     public function testImageHandlerRejectsOversizedUpload(): void
     {
         $handler = new \SessionApiHandler();
-        $oversized = str_repeat('a', 2_097_153);
+        $oversized = str_repeat('a', 1_048_577);
         $request = (new ServerRequestFactory())->createServerRequest('POST', 'http://localhost/api/app/x/image')
             ->withParsedBody(['pictureType' => 'contextImage'])
             ->withUploadedFiles(['image' => $this->createUploadedFile($oversized)]);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Zbyt duże zdjęcie (>2MB)');
+        $this->expectExceptionMessage('Zbyt duże zdjęcie (>1MB)');
 
         $handler->image($request, new Response(), ['appId' => 'unused']);
     }

--- a/tests/API/ImageUploadTest.php
+++ b/tests/API/ImageUploadTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace UprzejmieDonosze\Tests\API;
+
+require_once __DIR__ . '/../../export/inc/handlers/SessionApiHandler.php';
+
+use app\Application;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Factory\UploadedFileFactory;
+use Slim\Psr7\Response;
+use user\User;
+
+class ImageUploadTest extends TestCase
+{
+    /** @var list<string> */
+    private array $pathsToRemove = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->pathsToRemove as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        $this->pathsToRemove = [];
+    }
+
+    private function createSavedUser(string $email = 'image-upload-test@example.com'): User
+    {
+        $_SESSION['user_email'] = $email;
+        $_SESSION['user_id'] = 'phpunit-user-id';
+        $user = new User();
+        $user->email = $email;
+        \user\save($user);
+        return $user;
+    }
+
+    private function makeJpegBytes(int $width = 40, int $height = 30): string
+    {
+        $img = imagecreatetruecolor($width, $height);
+        ob_start();
+        imagejpeg($img, null, 90);
+        $bytes = ob_get_clean();
+        imagedestroy($img);
+        return $bytes;
+    }
+
+    private function trackOutputFiles(string $baseFileName, string $type): void
+    {
+        $this->pathsToRemove[] = ROOT . "$baseFileName,$type.jpg";
+        $this->pathsToRemove[] = ROOT . "$baseFileName,$type,t.jpg";
+    }
+
+    private function createUploadedFile(string $bytes, string $filename = 'image.jpg'): \Psr\Http\Message\UploadedFileInterface
+    {
+        $stream = (new StreamFactory())->createStream($bytes);
+        return (new UploadedFileFactory())->createUploadedFile(
+            $stream,
+            strlen($bytes),
+            UPLOAD_ERR_OK,
+            $filename,
+            'image/jpeg'
+        );
+    }
+
+    public function testSaveImgAndThumbWritesJpegAndThumbFromRawBytes(): void
+    {
+        $user = $this->createSavedUser('img-thumb-test@example.com');
+        $app = Application::withUser($user);
+        $jpeg = $this->makeJpegBytes();
+        $type = 'co';
+
+        $baseFileName = saveImgAndThumb($app, $jpeg, $type);
+        $this->trackOutputFiles($baseFileName, $type);
+
+        $fullPath = ROOT . "$baseFileName,$type.jpg";
+        $thumbPath = ROOT . "$baseFileName,$type,t.jpg";
+
+        $this->assertFileExists($fullPath);
+        $this->assertFileExists($thumbPath);
+        $this->assertSame('image/jpeg', mime_content_type($fullPath));
+        $this->assertSame('image/jpeg', mime_content_type($thumbPath));
+    }
+
+    public function testSaveImgAndThumbRejectsInvalidBytes(): void
+    {
+        $user = $this->createSavedUser('img-invalid-test@example.com');
+        $app = Application::withUser($user);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Przesłany plik nie jest obrazkiem');
+
+        saveImgAndThumb($app, 'not-an-image', 'co');
+    }
+
+    public function testUploadImageContextImageFromRawBytes(): void
+    {
+        $user = $this->createSavedUser();
+        $app = Application::withUser($user);
+        $app->statusHistory = [];
+        $app->comments = [];
+        $app->extensions = [];
+        \app\save($app);
+
+        $jpeg = $this->makeJpegBytes(120, 90);
+        $updated = uploadImage($app->id, 'contextImage', $jpeg, null, null, null);
+
+        $this->trackOutputFiles(
+            \storage\cdnPrefix() . '/' . $updated->getUserNumber() . '/' . $updated->id,
+            'co'
+        );
+
+        $this->assertNotEmpty($updated->contextImage->url);
+        $this->assertNotEmpty($updated->contextImage->thumb);
+        $this->assertFileExists(ROOT . $updated->contextImage->url);
+        $this->assertFileExists(ROOT . $updated->contextImage->thumb);
+        $this->assertSame(120, $updated->contextImage->width);
+        $this->assertSame(90, $updated->contextImage->height);
+    }
+
+    public function testImageHandlerRejectsMissingUpload(): void
+    {
+        $handler = new \SessionApiHandler();
+        $request = (new ServerRequestFactory())->createServerRequest('POST', 'http://localhost/api/app/x/image')
+            ->withParsedBody(['pictureType' => 'contextImage']);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Brak pliku obrazka');
+
+        $handler->image($request, new Response(), ['appId' => 'unused']);
+    }
+
+    public function testImageHandlerRejectsOversizedUpload(): void
+    {
+        $handler = new \SessionApiHandler();
+        $oversized = str_repeat('a', 2_097_153);
+        $request = (new ServerRequestFactory())->createServerRequest('POST', 'http://localhost/api/app/x/image')
+            ->withParsedBody(['pictureType' => 'contextImage'])
+            ->withUploadedFiles(['image' => $this->createUploadedFile($oversized)]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Zbyt duże zdjęcie (>2MB)');
+
+        $handler->image($request, new Response(), ['appId' => 'unused']);
+    }
+}


### PR DESCRIPTION
closes #18 
closes #15
closes #24 

Od iOS 18 zdjęcia HEIC z iPhone'a nie przechodzą przez formularz zgłoszenia. W konsoli widać błędy, m.in. _Could not parse HEIF file_ albo _ERR_LIBHEIF format not supported_.

Obecnie używana w projekcie biblioteka **heic2any**, używa pod spodem starą wersję **libheif**, która nie ogarnia nowszych plików z iPhone'a. Konwersja do JPEG pada zanim cokolwiek poleci na serwer - backend w ogóle nie dostaje pliku.

**Problem był zgłaszany wielokrotnie przez użytkowników, min:**
https://github.com/alexcorvi/heic2any/issues/63
https://github.com/alexcorvi/heic2any/issues/61
https://github.com/strukturag/libheif/issues/1190

**Biblioteka heic2any nie jest aktywnie wspierana od ok 2023 roku.**

**Opis zmian:**
- Zastępujemy **heic2any** nowszą biblioteką **heic-to**
- W Safari (iPhone/MacOs) najpierw próbujemy użyć systemowego dekodera HEIC od Apple (createImageBitmap()), jak to nie zadziała, dopiero wczytujemy bibliotekę **heic-to**, poprzez lazy import
- Lepsze wykrywanie plików HEIC (MIME + sygnatura ftyp w pliku)
- Lepsza obsługa błędów przy konwersji - wcześniej błąd mógł wylecieć jako nieobsłużony promise


**Przed zmianami:**
<img width="1470" height="420" alt="image" src="https://github.com/user-attachments/assets/ea5e9749-74d4-41bf-9cdb-701a80df97b3" />

**Po zmianach:**
<img width="1147" height="850" alt="image" src="https://github.com/user-attachments/assets/7cb5ec13-7574-4b44-a900-563eb0baabd2" />


Swoją drogą, w projekcie przydałby się jakiś przykładowy `.env.dev` do lokalnego developmentu, żeby nie musieć się domyślać co ustawić a co nie 
