### PR TITLE
Fix HEIC iOS18 upload (#18) + multipart image upload (#15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "exifreader": "^4.36.2",
         "firebase": "^12.9.0",
         "firebaseui": "^6.1.0",
-        "heic2any": "^0.0.4",
+        "heic-to": "^1.5.2",
         "highcharts": "^11.4.8",
         "lazysizes": "^5.3.2",
         "luxon": "^3.7.2",
@@ -6565,11 +6565,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/heic2any": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
-      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
-      "license": "MIT"
+    "node_modules/heic-to": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
+      "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
+      "license": "LGPL-3.0"
     },
     "node_modules/highcharts": {
       "version": "11.4.8",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "exifreader": "^4.36.2",
     "firebase": "^12.9.0",
     "firebaseui": "^6.1.0",
-    "heic2any": "^0.0.4",
+    "heic-to": "^1.5.2",
     "highcharts": "^11.4.8",
     "lazysizes": "^5.3.2",
     "luxon": "^3.7.2",

--- a/services/webapp/nginx.conf
+++ b/services/webapp/nginx.conf
@@ -35,8 +35,6 @@ http {
     server {
         listen 80;
 
-        client_max_body_size 10m;
-
         etag on;
 
         add_header X-Frame-Options "SAMEORIGIN" always;
@@ -86,6 +84,11 @@ http {
             try_files $uri =404;
             root $CDN_ROOT;
         }
+        location ~ ^/api/app/[^/]+/image$ {
+            client_max_body_size 10m;
+            try_files $uri /index.php$is_args$args;
+        }
+
         location ~ ^/api/rest {
             try_files $uri $uri/ /api/rest/index.php$is_args$args;
                 location ~ \.php$ {

--- a/services/webapp/nginx.conf
+++ b/services/webapp/nginx.conf
@@ -35,6 +35,8 @@ http {
     server {
         listen 80;
 
+        client_max_body_size 10m;
+
         etag on;
 
         add_header X-Frame-Options "SAMEORIGIN" always;

--- a/src/api/rest/index.php
+++ b/src/api/rest/index.php
@@ -320,7 +320,7 @@ $app->group('/api/rest/app', function (RouteCollectorProxy $group) { // APPLICAT
             throw new HttpException($request, "Niewspierane rozszerzenie $ext", 415);
         
         $appId = $request->getAttribute('application')->id;
-        $application = uploadImage($appId, $pictureType, $imageBytes, $dateTime, $dtFromPicture, $latLng);
+        $application = uploadImage($appId, $pictureType, base64_decode($imageBytes, true), $dateTime, $dtFromPicture, $latLng);
         unset($application->browser);
         $response->getBody()->write(json_encode($application));
         return $response;

--- a/src/inc/API.php
+++ b/src/inc/API.php
@@ -10,6 +10,11 @@ use \Exception as Exception;
 use user\User;
 use cache\Type;
 
+// Must match MAX_IMAGE_DIM / JPEG_QUALITY on the client (src/js/new-app/images.js):
+// the browser already resizes to these before upload; the server re-enforces them.
+const MAX_IMAGE_DIM = 1600;
+const JPEG_QUALITY = 85;
+
 /**
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
  */
@@ -199,7 +204,7 @@ function saveImgAndThumb($application, $imageBytes, $type) {
     $fileName     = ROOT . "$baseFileName,$type.jpg";
     $thumbName    = ROOT . "$baseFileName,$type,t.jpg";
 
-    $rawBytes = base64_decode($imageBytes);
+    $rawBytes = $imageBytes;
     $info = getimagesizefromstring($rawBytes);
     if ($info === false) {
         throw new Exception("Przesłany plik nie jest obrazkiem", 400);
@@ -223,14 +228,14 @@ function saveImgAndThumb($application, $imageBytes, $type) {
         throw new Exception("Nieobsługiwany format obrazka: {$info['mime']}", 415);
     }
 
-    if (!imagejpeg($img, $fileName, 85)) {
+    if (!imagejpeg($img, $fileName, JPEG_QUALITY)) {
         throw new Exception("Can't write to $fileName", 500);
     }
     imagedestroy($img);
 
     $fullSize = getimagesize($fileName);
-    if ($fullSize[0] > 1600 || $fullSize[1] > 1600) {
-        imagejpeg(resize_image($fileName, 1600, 1600, false), $fileName, 95);
+    if ($fullSize[0] > MAX_IMAGE_DIM || $fullSize[1] > MAX_IMAGE_DIM) {
+        imagejpeg(resize_image($fileName, MAX_IMAGE_DIM, MAX_IMAGE_DIM, false), $fileName, JPEG_QUALITY);
     }
 
     if (!imagejpeg(resize_image($fileName, 600, 600, false), $thumbName)) {

--- a/src/inc/handlers/SessionApiHandler.php
+++ b/src/inc/handlers/SessionApiHandler.php
@@ -11,6 +11,9 @@ use Slim\Exception\HttpNotFoundException;
 
 class SessionApiHandler extends AbstractHandler {
 
+    /** Hard limit: client caps uploads at 1600×1600 JPEG Q0.85, which stays under 1MB. */
+    private const MAX_IMAGE_UPLOAD_BYTES = 1_048_576;
+
     private function checkEditable(Request $request, Application $app) {
         if (!$app->isEditable())
             throw new HttpForbiddenException($request, "Zgłoszenie {$app->id} nie może być edytowane");
@@ -124,8 +127,26 @@ class SessionApiHandler extends AbstractHandler {
     public function image(Request $request, Response $response, $args): Response {
         $appId = $args['appId'];
         $params = (array)$request->getParsedBody();
+        $uploadedFiles = $request->getUploadedFiles();
 
-        $imageBytes = explode( ',', $this->getParam($params, 'image_data'))[1];
+        if (!isset($uploadedFiles['image'])) {
+            throw new Exception("Brak pliku obrazka", 400);
+        }
+
+        $upload = $uploadedFiles['image'];
+        if ($upload->getError() !== UPLOAD_ERR_OK) {
+            throw new Exception("Błąd przesyłania pliku (kod {$upload->getError()})", 400);
+        }
+        $tooLarge = "Zbyt duże zdjęcie (>" . (self::MAX_IMAGE_UPLOAD_BYTES >> 20) . "MB)";
+        // Reject by declared size before buffering the stream into memory.
+        if ($upload->getSize() > self::MAX_IMAGE_UPLOAD_BYTES) {
+            throw new Exception($tooLarge, 400);
+        }
+        $imageBytes = $upload->getStream()->getContents();
+        if (strlen($imageBytes) > self::MAX_IMAGE_UPLOAD_BYTES) {
+            throw new Exception($tooLarge, 400);
+        }
+
         $pictureType = $this->getParam($params, 'pictureType');
 
         $dateTime = isset($params['dateTime']) ? $params['dateTime'] : null;

--- a/src/inc/integrations/openAlpr.php
+++ b/src/inc/integrations/openAlpr.php
@@ -87,7 +87,7 @@ function get_alpr(&$imageBytes){
 	$apiInstance = new \Swagger\Client\Api\DefaultApi();
 
     try {
-        $alpr = $apiInstance->recognizeBytes($imageBytes, OPEN_ALPR_SECRET_1,
+        $alpr = $apiInstance->recognizeBytes(base64_encode($imageBytes), OPEN_ALPR_SECRET_1,
             "eu", // country
             1, // recognize_vehicle
             "", // state

--- a/src/inc/integrations/plateRecognizer.php
+++ b/src/inc/integrations/plateRecognizer.php
@@ -56,7 +56,7 @@ function get_platerecognizer(&$imageBytes) {
     }
 
     $data = array(
-        'upload' => $imageBytes,
+        'upload' => base64_encode($imageBytes),
         'regions' => 'pl',
         'mmc' => true
     );

--- a/src/js/lib/Api.js
+++ b/src/js/lib/Api.js
@@ -31,6 +31,18 @@ export default class Api {
   async post(data, headers={}) {
     return await this.#postOrPatch(data, 'POST', headers)
   }
+
+  async postForm(data, headers={}) {
+    const response = await fetch(this.url, {
+      headers: {
+        'Accept': 'application/json',
+        ...headers
+      },
+      method: 'POST',
+      body: data
+    })
+    return await this.#parseResponse(response)
+  }
   
   async patch(data, headers={}) {
     return await this.#postOrPatch(data, 'PATCH', headers)

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -1,4 +1,3 @@
-import heic2any from "heic2any"
 import ExifReader from 'exifreader'
 
 import { setAddressByLatLng } from "../lib/geolocation";
@@ -9,6 +8,11 @@ import * as Sentry from "@sentry/browser";
 import { error } from "../lib/toast";
 import { updateRecydywa } from "./recydywa";
 import { setOcrVehicleInfo, triggerVehicleInfoEnrichment, appendAutoComment } from "./vehicle-info";
+
+// Matches the JPEG quality used by saveImgAndThumb in API.php (85);
+// keeps a resized 1600px upload around ~1 MB.
+const JPEG_QUALITY = 0.85
+const MAX_IMAGE_DIM = 1600
 
 var uploadInProgress = 0;
 
@@ -28,48 +32,46 @@ export async function checkFile(file, id) {
     );
   }
 
-  const imageToResize = document.createElement('img')
+  let previewUrl = null
+  try {
+    const prepared = await prepareUploadBlob(file)
+    previewUrl = prepared.previewUrl
 
-  imageToResize.src = await imageToDataUri(file)
-  imageToResize.addEventListener("load", async () => {
-    try {
-      const resizedImage = resizeImage(imageToResize)
-      const previewElement = /** @type {HTMLImageElement} */ (document.getElementById(`${id}Preview`))
-      if (previewElement) {
-        previewElement.style.opacity = '0.3'
-        previewElement.src = resizedImage
-      }
-
-      if (id === "carImage") {
-        const exif = await ExifReader.load(file)
-        const [lat, lng] = readGeoDataFromExif(exif)
-        let dateTime = getDateTimeFromExif(exif)
-
-        dateTime = setDateTime(dateTime, !!dateTime)
-        if (lat) setAddressByLatLng(lat, lng, "picture")
-        else noGeoDataInImage()
-
-        const plateImage = /** @type {HTMLImageElement} */ (document.getElementById("plateImage"))
-        if (plateImage) {
-          plateImage.src = ""
-          plateImage.style.display = 'none'
-        }
-        await sendFile(resizedImage, id, {
-          dateTime,
-          dtFromPicture: !!dateTime,
-          latLng: `${lat},${lng}`
-        });
-      } else {
-        await sendFile(resizedImage, id);
-      }
-
-    } catch (err) {
-      imageError(id, err.message);
-      Sentry.captureException(err, {
-        extra: Object.prototype.toString.call(file)
-      });
+    const previewElement = /** @type {HTMLImageElement} */ (document.getElementById(`${id}Preview`))
+    if (previewElement) {
+      previewElement.style.opacity = '0.3'
+      previewElement.src = previewUrl
     }
-  })
+
+    if (id === "carImage") {
+      const exif = await ExifReader.load(file)
+      const [lat, lng] = readGeoDataFromExif(exif)
+      let dateTime = getDateTimeFromExif(exif)
+
+      dateTime = setDateTime(dateTime, !!dateTime)
+      if (lat) setAddressByLatLng(lat, lng, "picture")
+      else noGeoDataInImage()
+
+      const plateImage = /** @type {HTMLImageElement} */ (document.getElementById("plateImage"))
+      if (plateImage) {
+        plateImage.src = ""
+        plateImage.style.display = 'none'
+      }
+      await sendFile(prepared.blob, id, {
+        dateTime,
+        dtFromPicture: !!dateTime,
+        latLng: `${lat},${lng}`
+      }, previewUrl);
+    } else {
+      await sendFile(prepared.blob, id, {}, previewUrl);
+    }
+  } catch (err) {
+    revokeObjectUrl(previewUrl)
+    imageError(id, err.message || String(err));
+    Sentry.captureException(err, {
+      extra: { fileType: file.type }
+    });
+  }
 
 }
 
@@ -152,46 +154,146 @@ function getDateTimeFromExif(exif) {
   return dateTime?.description
 }
 
-async function imageToDataUri(img) {
-  if (img.type.includes('hei')) {
-    const blob = await heic2any({ blob: img, toType: "image/jpeg" })
-    return URL.createObjectURL(blob)
-  } else {
-    return await pngToDataUri(img)
+async function isHeicFile(file) {
+  if (/hei(c|f)/i.test(file.type)) return true
+  if (file.size < 12) return false
+  const buf = await file.slice(4, 12).arrayBuffer()
+  const brand = String.fromCharCode(...new Uint8Array(buf))
+  return brand.startsWith('ftyp') && /hei[cfx]|mif1|msf1/.test(brand)
+}
+
+function revokeObjectUrl(url) {
+  if (url?.startsWith('blob:')) URL.revokeObjectURL(url)
+}
+
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = document.createElement('img')
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('Nie można wczytać zdjęcia'))
+    img.src = src
+  })
+}
+
+/**
+ * Decodes fileOrBlob with EXIF orientation applied and passes the source to fn.
+ * Prefers createImageBitmap, falling back to an <img> element (e.g. no bitmap
+ * support, or a decode error). Always closes/revokes the decoded source.
+ * @template T
+ * @param {Blob} fileOrBlob
+ * @param {(source: CanvasImageSource & { width: number, height: number }) => T | Promise<T>} fn
+ * @param {Record<string, unknown>} [sentryExtra]
+ * @returns {Promise<T>}
+ */
+async function withDecodedImage(fileOrBlob, fn, sentryExtra = {}) {
+  if (typeof createImageBitmap === 'function') {
+    try {
+      const bitmap = await createImageBitmap(fileOrBlob, { imageOrientation: 'from-image' })
+      try {
+        return await fn(bitmap)
+      } finally {
+        bitmap.close()
+      }
+    } catch (err) {
+      Sentry.captureException(err, { extra: { decoder: 'bitmap', ...sentryExtra } })
+    }
+  }
+
+  const url = URL.createObjectURL(fileOrBlob)
+  try {
+    const img = await loadImage(url)
+    return await fn(img)
+  } finally {
+    revokeObjectUrl(url)
   }
 }
 
-function pngToDataUri(field) {
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-
-    reader.addEventListener("load", () => {
-      resolve(reader.result);
-    });
-
-    reader.readAsDataURL(field);
-  });
+async function getImageDimensions(fileOrBlob) {
+  return withDecodedImage(
+    fileOrBlob,
+    source => ({ width: source.width, height: source.height }),
+    { op: 'dimensions' }
+  )
 }
 
-function resizeImage(imgToResize) {
+function fitsMaxDimensions(width, height) {
+  return width <= MAX_IMAGE_DIM && height <= MAX_IMAGE_DIM
+}
+
+/**
+ * Converts a HEIC file to a JPEG blob. The native path also returns the decoded
+ * dimensions so the caller can skip a redundant decode; the heic-to fallback
+ * reports null dimensions (caller resolves them separately).
+ * @returns {Promise<{ blob: Blob, width: number|null, height: number|null }>}
+ */
+async function heicToJpegBlob(file) {
+  if (typeof createImageBitmap === 'function') {
+    try {
+      const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' })
+      const { width, height } = bitmap
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) throw new Error('Canvas not supported')
+      ctx.fillStyle = '#ffffff'
+      ctx.fillRect(0, 0, width, height)
+      ctx.drawImage(bitmap, 0, 0)
+      bitmap.close()
+      const blob = await new Promise((resolve, reject) =>
+        canvas.toBlob(b => b ? resolve(b) : reject(new Error('Conversion failed')), 'image/jpeg', JPEG_QUALITY)
+      )
+      return { blob, width, height }
+    } catch (err) {
+      Sentry.captureException(err, { extra: { heicDecoder: 'native' } })
+    }
+  }
+
+  const { heicTo } = await import('heic-to')
+  const blob = await heicTo({ blob: file, type: 'image/jpeg', quality: JPEG_QUALITY })
+  return { blob, width: null, height: null }
+}
+
+/** @returns {Promise<{ blob: Blob, previewUrl: string }>} */
+async function prepareUploadBlob(file) {
+  if (await isHeicFile(file)) {
+    let { blob: jpegBlob, width, height } = await heicToJpegBlob(file)
+    if (width == null) ({ width, height } = await getImageDimensions(jpegBlob))
+    if (fitsMaxDimensions(width, height)) {
+      return { blob: jpegBlob, previewUrl: URL.createObjectURL(jpegBlob) }
+    }
+
+    const blob = await resizeBlob(jpegBlob)
+    return { blob, previewUrl: URL.createObjectURL(blob) }
+  }
+
+  // Always decode non-HEIC images through the canvas so EXIF orientation is
+  // baked into the pixels — the server (GD) strips the EXIF tag on re-encode.
+  const blob = await resizeBlob(file)
+  return { blob, previewUrl: URL.createObjectURL(blob) }
+}
+
+async function resizeBlob(fileOrBlob) {
+  return withDecodedImage(fileOrBlob, resizeSource, { op: 'resize' })
+}
+
+/** @param {CanvasImageSource & { width: number, height: number }} source */
+function resizeSource(source) {
   const canvas = document.createElement("canvas");
   const context = canvas.getContext("2d");
 
-  const MAX_WIDTH = 1600;
-  const MAX_HEIGHT = 1600;
-  let canvasWidth = imgToResize.width;
-  let canvasHeight = imgToResize.height;
+  let canvasWidth = source.width;
+  let canvasHeight = source.height;
 
-  // Add the resizing logic
   if (canvasWidth > canvasHeight) {
-    if (canvasWidth > MAX_WIDTH) {
-      canvasHeight *= MAX_WIDTH / canvasWidth;
-      canvasWidth = MAX_WIDTH;
+    if (canvasWidth > MAX_IMAGE_DIM) {
+      canvasHeight *= MAX_IMAGE_DIM / canvasWidth;
+      canvasWidth = MAX_IMAGE_DIM;
     }
   } else {
-    if (canvasHeight > MAX_HEIGHT) {
-      canvasWidth *= MAX_HEIGHT / canvasHeight;
-      canvasHeight = MAX_HEIGHT;
+    if (canvasHeight > MAX_IMAGE_DIM) {
+      canvasWidth *= MAX_IMAGE_DIM / canvasHeight;
+      canvasHeight = MAX_IMAGE_DIM;
     }
   }
 
@@ -199,13 +301,19 @@ function resizeImage(imgToResize) {
   canvas.height = canvasHeight;
 
   context?.drawImage(
-    imgToResize,
+    source,
     0,
     0,
     canvasWidth,
     canvasHeight
   );
-  return canvas.toDataURL("image/jpeg", 0.95);
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      blob => blob ? resolve(blob) : reject(new Error('Nie udało się przetworzyć zdjęcia')),
+      'image/jpeg',
+      JPEG_QUALITY
+    )
+  })
 }
 
 function noGeoDataInImage() {
@@ -265,22 +373,22 @@ export function repositionCarImage(vehicleBox, imageWidth, imageHeight) {
 }
 
 /**
- * @param {*} fileData
+ * @param {Blob} fileData
  * @param {'contextImage' | 'carImage' | 'thirdImage'} id
  * @param {*} imageMetadata
+ * @param {string|null} previewUrl
  */
-async function sendFile(fileData, id, imageMetadata={}) {
+async function sendFile(fileData, id, imageMetadata={}, previewUrl=null) {
   const appIdElement = /** @type {HTMLInputElement} */ (document.querySelector(".new-application #applicationId"))
   const appId = appIdElement?.value
-  var data = {
-    image_data: fileData,
-    pictureType: id
-  }
+  const data = new FormData()
+  data.append('image', fileData, 'image.jpg')
+  data.append('pictureType', id)
 
   if (id == "carImage") {
-    imageMetadata.dateTime && (data.dateTime = imageMetadata.dateTime)
-    imageMetadata.dtFromPicture && (data.dtFromPicture = imageMetadata.dtFromPicture)
-    imageMetadata.latLng && (data.latLng = imageMetadata.latLng)
+    imageMetadata.dateTime && data.append('dateTime', imageMetadata.dateTime)
+    imageMetadata.dtFromPicture && data.append('dtFromPicture', 'true')
+    imageMetadata.latLng && data.append('latLng', imageMetadata.latLng)
   }
   if (id == "thirdImage") {
     showThirdImage(true)
@@ -294,7 +402,7 @@ async function sendFile(fileData, id, imageMetadata={}) {
 
   try {
     const api = new Api(`/api/app/${appId}/image`)
-    const app = await api.post(data)
+    const app = await api.postForm(data)
     if (app.carImage || app.contextImage || app.thirdImage) {
       const loader = document.querySelector(`.${id}Section .loader`)
       const preview = /** @type {HTMLImageElement} */ (document.getElementById(`${id}Preview`))
@@ -346,6 +454,8 @@ async function sendFile(fileData, id, imageMetadata={}) {
     uploadFinished()
   } catch (err) {
     imageError(id, err.toString())
+  } finally {
+    revokeObjectUrl(previewUrl)
   }
 }
 

--- a/src/js/new-app/images.js
+++ b/src/js/new-app/images.js
@@ -231,19 +231,22 @@ async function heicToJpegBlob(file) {
     try {
       const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' })
       const { width, height } = bitmap
-      const canvas = document.createElement('canvas')
-      canvas.width = width
-      canvas.height = height
-      const ctx = canvas.getContext('2d')
-      if (!ctx) throw new Error('Canvas not supported')
-      ctx.fillStyle = '#ffffff'
-      ctx.fillRect(0, 0, width, height)
-      ctx.drawImage(bitmap, 0, 0)
-      bitmap.close()
-      const blob = await new Promise((resolve, reject) =>
-        canvas.toBlob(b => b ? resolve(b) : reject(new Error('Conversion failed')), 'image/jpeg', JPEG_QUALITY)
-      )
-      return { blob, width, height }
+      try {
+        const canvas = document.createElement('canvas')
+        canvas.width = width
+        canvas.height = height
+        const ctx = canvas.getContext('2d')
+        if (!ctx) throw new Error('Canvas not supported')
+        ctx.fillStyle = '#ffffff'
+        ctx.fillRect(0, 0, width, height)
+        ctx.drawImage(bitmap, 0, 0)
+        const blob = await new Promise((resolve, reject) =>
+          canvas.toBlob(b => b ? resolve(b) : reject(new Error('Conversion failed')), 'image/jpeg', JPEG_QUALITY)
+        )
+        return { blob, width, height }
+      } finally {
+        bitmap.close()
+      }
     } catch (err) {
       Sentry.captureException(err, { extra: { heicDecoder: 'native' } })
     }

--- a/src/templates/changelog.html.twig
+++ b/src/templates/changelog.html.twig
@@ -21,6 +21,7 @@
     <li>Zmiana domyślnego odbiorcy zgłoszeń z SM na Policję (dla nowozarejestrowanych użytkowników).</li>
     <li>Wybór jednostki (Straż Miejska / Policja) nie jest już pytaniem przy rejestracji konta — zapamiętujemy go automatycznie na podstawie wyboru dokonanego przy zgłoszeniu, a nowe konta domyślnie startują ze Strażą Miejską.</li>
     <li>Skrzynki #stopagresji są teraz traktowane jako gwarantowany, ostateczny fallback przy wysyłce na Policję, a nie jako lista konkretnych komisariatów — dzięki temu więcej zgłoszeń trafia bezpośrednio do właściwego, lokalnego komisariatu.</li>
+    <li>Naprawiono błąd występujący podczas wgrywania zdjęć w formacie HEIC zrobionych na iPhone'ach z systemem iOS 18 lub nowszym.</li>
 </ul>
 <h4>Środa, 24 czerwca 2026</h4>
 <ul>

--- a/tests/API/ImageUploadTest.php
+++ b/tests/API/ImageUploadTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace UprzejmieDonosze\Tests\API;
+
+require_once __DIR__ . '/../../export/inc/handlers/SessionApiHandler.php';
+
+use app\Application;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Factory\UploadedFileFactory;
+use Slim\Psr7\Response;
+use user\User;
+
+class ImageUploadTest extends TestCase
+{
+    /** @var list<string> */
+    private array $pathsToRemove = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->pathsToRemove as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        $this->pathsToRemove = [];
+    }
+
+    private function createSavedUser(string $email = 'image-upload-test@example.com'): User
+    {
+        $_SESSION['user_email'] = $email;
+        $_SESSION['user_id'] = 'phpunit-user-id';
+        $user = new User();
+        $user->email = $email;
+        \user\save($user);
+        return $user;
+    }
+
+    private function makeJpegBytes(int $width = 40, int $height = 30): string
+    {
+        $img = imagecreatetruecolor($width, $height);
+        ob_start();
+        imagejpeg($img, null, 90);
+        $bytes = ob_get_clean();
+        imagedestroy($img);
+        return $bytes;
+    }
+
+    private function trackOutputFiles(string $baseFileName, string $type): void
+    {
+        $this->pathsToRemove[] = ROOT . "$baseFileName,$type.jpg";
+        $this->pathsToRemove[] = ROOT . "$baseFileName,$type,t.jpg";
+    }
+
+    private function createUploadedFile(string $bytes, string $filename = 'image.jpg'): \Psr\Http\Message\UploadedFileInterface
+    {
+        $stream = (new StreamFactory())->createStream($bytes);
+        return (new UploadedFileFactory())->createUploadedFile(
+            $stream,
+            strlen($bytes),
+            UPLOAD_ERR_OK,
+            $filename,
+            'image/jpeg'
+        );
+    }
+
+    public function testSaveImgAndThumbWritesJpegAndThumbFromRawBytes(): void
+    {
+        $user = $this->createSavedUser('img-thumb-test@example.com');
+        $app = Application::withUser($user);
+        $jpeg = $this->makeJpegBytes();
+        $type = 'co';
+
+        $baseFileName = saveImgAndThumb($app, $jpeg, $type);
+        $this->trackOutputFiles($baseFileName, $type);
+
+        $fullPath = ROOT . "$baseFileName,$type.jpg";
+        $thumbPath = ROOT . "$baseFileName,$type,t.jpg";
+
+        $this->assertFileExists($fullPath);
+        $this->assertFileExists($thumbPath);
+        $this->assertSame('image/jpeg', mime_content_type($fullPath));
+        $this->assertSame('image/jpeg', mime_content_type($thumbPath));
+    }
+
+    public function testSaveImgAndThumbRejectsInvalidBytes(): void
+    {
+        $user = $this->createSavedUser('img-invalid-test@example.com');
+        $app = Application::withUser($user);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Przesłany plik nie jest obrazkiem');
+
+        saveImgAndThumb($app, 'not-an-image', 'co');
+    }
+
+    public function testUploadImageContextImageFromRawBytes(): void
+    {
+        $user = $this->createSavedUser();
+        $app = Application::withUser($user);
+        $app->statusHistory = [];
+        $app->comments = [];
+        $app->extensions = [];
+        \app\save($app);
+
+        $jpeg = $this->makeJpegBytes(120, 90);
+        $updated = uploadImage($app->id, 'contextImage', $jpeg, null, null, null);
+
+        $this->trackOutputFiles(
+            \storage\cdnPrefix() . '/' . $updated->getUserNumber() . '/' . $updated->id,
+            'co'
+        );
+
+        $this->assertNotEmpty($updated->contextImage->url);
+        $this->assertNotEmpty($updated->contextImage->thumb);
+        $this->assertFileExists(ROOT . $updated->contextImage->url);
+        $this->assertFileExists(ROOT . $updated->contextImage->thumb);
+        $this->assertSame(120, $updated->contextImage->width);
+        $this->assertSame(90, $updated->contextImage->height);
+    }
+
+    public function testImageHandlerRejectsMissingUpload(): void
+    {
+        $handler = new \SessionApiHandler();
+        $request = (new ServerRequestFactory())->createServerRequest('POST', 'http://localhost/api/app/x/image')
+            ->withParsedBody(['pictureType' => 'contextImage']);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Brak pliku obrazka');
+
+        $handler->image($request, new Response(), ['appId' => 'unused']);
+    }
+
+    public function testImageHandlerRejectsOversizedUpload(): void
+    {
+        $handler = new \SessionApiHandler();
+        $oversized = str_repeat('a', 1_048_577);
+        $request = (new ServerRequestFactory())->createServerRequest('POST', 'http://localhost/api/app/x/image')
+            ->withParsedBody(['pictureType' => 'contextImage'])
+            ->withUploadedFiles(['image' => $this->createUploadedFile($oversized)]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Zbyt duże zdjęcie (>1MB)');
+
+        $handler->image($request, new Response(), ['appId' => 'unused']);
+    }
+}


### PR DESCRIPTION
closes #18 
closes #15 
closes #24 

Od iOS 18 zdjęcia HEIC z iPhone'a nie przechodzą przez formularz zgłoszenia. W konsoli widać błędy, m.in. _Could not parse HEIF file_ albo _ERR_LIBHEIF format not supported_.

Obecnie używana w projekcie biblioteka **heic2any**, używa pod spodem starą wersję **libheif**, która nie ogarnia nowszych plików z iPhone'a. Konwersja do JPEG pada zanim cokolwiek poleci na serwer - backend w ogóle nie dostaje pliku.

**Problem był zgłaszany wielokrotnie przez użytkowników, min:**
https://github.com/alexcorvi/heic2any/issues/63
https://github.com/alexcorvi/heic2any/issues/61
https://github.com/strukturag/libheif/issues/1190

**Biblioteka heic2any nie jest aktywnie wspierana od ok 2023 roku.**

**Opis zmian:**
- Zastępujemy **heic2any** nowszą biblioteką **heic-to**
- W Safari (iPhone/MacOs) najpierw próbujemy użyć systemowego dekodera HEIC od Apple (createImageBitmap()), jak to nie zadziała, dopiero wczytujemy bibliotekę **heic-to**, poprzez lazy import
- Lepsze wykrywanie plików HEIC (MIME + sygnatura ftyp w pliku)
- Lepsza obsługa błędów przy konwersji - wcześniej błąd mógł wylecieć jako nieobsłużony promise
- Do testów można użyć plik który jest wgrany w #18  - już działa
- #15 Multipart upload zamiast base64 w JSON - payload jest mniejszy o ~33%, lżej dla serwera (mniejsze obciążenie procesora przez brak dekodowania base64, dodatkowo mniejsze zużycie pamięci).
- #24 Walidacja rozmiaru zdjęcia po stronie serwera (limit 1 MB po resize - spokojnie wystarczy na JPG 1600px @ 0.85) + client_max_body_size 10m w nginx jako zewnętrzny bufor na narzut multipart. Nie wiem jakie masz ustawienia obecnie na produkcji, ale że zdjęcie 10MB przechodzi, to zakładam że to taki górny rozsądny limit
- Orientacja EXIF - zdjęcia z telefonu (HEIC i zwykłe JPG) zapisują się teraz w poprawnej orientacji zamiast czasem bokiem; orientacja jest wypalana w piksele po stronie klienta, bo serwer (GD) i tak usuwa tag EXIF przy re-enkodowaniu.
- Podstawowe testy

**Przed zmianami:**
<img width="1470" height="420" alt="image" src="https://github.com/user-attachments/assets/ea5e9749-74d4-41bf-9cdb-701a80df97b3" />

**Po zmianach:**
<img width="1147" height="850" alt="image" src="https://github.com/user-attachments/assets/7cb5ec13-7574-4b44-a900-563eb0baabd2" />