### PR TITLE
Local dev: Mailpit + Firebase mail bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ staging: ## Sync code to staging server and rebuild Docker containers
 dev:
 	@docker compose \
         -f services/compose.yml \
-        --env-file services/.env.dev \
+        $(if $(wildcard services/.env.dev),--env-file services/.env.dev,) \
         -p $@ \
         --profile $@ \
         up --build
@@ -178,6 +178,10 @@ dev:
 .PHONY: emulator-ui
 emulator-ui: ## Open Firebase emulator UI in browser
 	@open http://localhost:4000
+
+.PHONY: mailpit-ui
+mailpit-ui: ## Open Mailpit inbox in browser
+	@open http://localhost:8025
 
 # ── Help ──────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,18 @@ git clone git@github.com:uprzejmiedonosze/uprzejmiedonosze.git
 cd uprzejmiedonosze
 ```
 
-## Local secrets setup
+## Local config
 
-Create `services/.env.dev` (gitignored) with your dev credentials. Use the structure below — all values are required for full functionality, but the app will start without optional ones:
+**`config.dev.php`** (repo root, committed) is the dev bootstrap: fixture crypto keys
+(matching `services/devroot/db/store.sqlite`), Mailpit/mail defaults, and API placeholders.
+After clone, `make dev` is enough — no extra setup required.
+
+Docker mounts this file into the webapp. Constants from the file take precedence; Docker env
+vars (from optional `services/.env.dev`) only apply to settings **not** already defined there.
+
+Optional **`services/.env.dev`** (gitignored) — only if you need real third-party tokens, e.g.:
 
 ```bash
-# Mandatory for encryption / sessions
-CRYPTO_KEY=...
-CRYPTO_IV=...
-CRYPTO_TAG=...
-
-# Firebase, Maps, ALPR, Mail, etc. (optional — app runs without them)
 MAPBOX_API_TOKEN=...
 GOOGLE_MAPS_API_TOKEN=...
 # ... see AGENTS.md for the full list
@@ -48,6 +49,12 @@ The dev profile starts a **Firebase Auth Emulator** automatically — no real Fi
 
 If you need a real Firebase project (for staging/prod), see the maintainer.
 
+## Email preview (Mailpit)
+
+The dev profile also starts **Mailpit** — outgoing mail is captured locally instead of hitting Mailgun. After sending a report, open the inbox at `http://localhost:8025` to preview the message body and PDF/ZIP attachments.
+
+Configured via `MAILER_DSN` in `config.dev.php` (`smtp://mailpit:1025`). If the DSN is missing, dev falls back to dry-run (status updates, no message captured).
+
 ## Running
 
 ```bash
@@ -57,8 +64,10 @@ make dev
 This is equivalent to:
 
 ```bash
-docker compose -f services/compose.yml --env-file services/.env.dev -p dev --profile dev up --build
+docker compose -f services/compose.yml -p dev --profile dev up --build
 ```
+
+(`services/.env.dev` is optional — see [Local config](#local-config).)
 
 The first run takes a few minutes (builds Docker images, compiles CSS/JS). Subsequent runs are fast thanks to Docker layer cache.
 
@@ -78,6 +87,11 @@ The Firebase emulator maps all logins to the pre-filled test account `e@nieradka
 **Open Firebase emulator UI:**
 ```bash
 make emulator-ui
+```
+
+**Open Mailpit (local email inbox):**
+```bash
+make mailpit-ui
 ```
 
 **View logs:**
@@ -101,7 +115,7 @@ make test
 ```
 services/
 ├── compose.yml              # All Docker services (profiles: dev / staging / prod)
-├── .env.dev                 # Local secrets (gitignored, create manually)
+├── .env.dev                 # Optional extra secrets (gitignored)
 ├── face-detector/           # Python face detection service
 ├── webapp/
 │   ├── Dockerfile           # builder + webapp + worker stages
@@ -114,6 +128,7 @@ services/
 
 src/                         # All source files (never edit export/ directly)
 export/                      # Built artifacts (gitignored, populated by builder)
+config.dev.php               # Committed dev bootstrap (crypto fixture, Mailpit, etc.)
 ```
 
 ## Troubleshooting

--- a/config.dev.php
+++ b/config.dev.php
@@ -1,4 +1,6 @@
 <?php
+// Dev bootstrap — committed fixture config (pairs with services/devroot/db/store.sqlite).
+// Loaded in Docker dev via compose mount; copied to export/ by watch.sh as a fallback.
 define('PLATERECOGNIZER_SECRET', 'contact author');
 define('OPEN_ALPR_SECRET_1', 'contact author');
 define('OPEN_ALPR_SECRET_2', 'contact author');
@@ -9,6 +11,10 @@ define('OPENAI_API_KEY', 'see README.md');
 define('OPENAI_PROJECT', 'proj_SOMEID');
 
 define('MAILER_FROM', 'u@dka.email');
+define('MAILER_FROM_ALTER', 'u@dka.email');
+define('EMAIL_SENDER', 'u@dka.email');
+define('MAILER_DSN', 'smtp://mailpit:1025');
+define('MAILER_DSN_ALTER', 'smtp://mailpit:1025');
 
 define('CRYPTO_KEY', '7700bcc0327517849e966dd169791439');
 define('CRYPTO_IV', '330adc20ed7dcf8561ff4869dd434b85');

--- a/services/compose.yml
+++ b/services/compose.yml
@@ -1,8 +1,8 @@
 name: ${APP_ENV:-dev}
 
-# App secrets and environment-specific config — passed to all PHP-running services.
-# Staging/prod: vars come from --env-file substitution (services/.env.staging / .env.prod).
-# Dev: loaded directly into the webapp container via env_file: .env.dev.
+# App secrets and environment-specific config.
+# Staging/prod: vars from --env-file (services/.env.staging / .env.prod) via x-app-env.
+# Dev: committed config.dev.php (mounted into webapp/builder) + optional services/.env.dev for extras.
 x-app-env: &app-env
   APP_ENV: ${APP_ENV:-prod}
   SMTP_HOST: ${SMTP_HOST:-}
@@ -50,6 +50,37 @@ services:
       - 4000:4000
     restart: always
 
+  mailpit:
+    profiles: [dev]
+    image: axllent/mailpit:latest
+    container_name: mailpit
+    ports:
+      - 8025:8025
+      - 1025:1025
+    restart: always
+
+  # Relays Firebase Auth Emulator OOB links (sign-in/reset) into Mailpit, since
+  # the emulator never sends real email. Gives dev a prod-like sign-in flow:
+  # the message lands in http://localhost:8025 with a clickable link.
+  firebase-mail-bridge:
+    profiles: [dev]
+    image: python:3-alpine
+    container_name: firebase-mail-bridge
+    restart: always
+    volumes:
+      - ./firebase-mail-bridge/bridge.py:/bridge.py:ro
+    environment:
+      EMULATOR_HOST: "firebase-emulator:9099"
+      FIREBASE_PROJECT: "demo-project"
+      BRIDGE_SMTP_HOST: "mailpit"
+      BRIDGE_SMTP_PORT: "1025"
+    command: ["python", "/bridge.py"]
+    depends_on:
+      firebase-emulator:
+        condition: service_started
+      mailpit:
+        condition: service_started
+
   builder:
     profiles: [dev]
     build:
@@ -66,6 +97,7 @@ services:
       - ../tests:/build/tests:ro
       - ../tools:/build/tools:ro
       - ../export:/build/export
+      - ../config.dev.php:/build/config.dev.php:ro
       - ./webapp/watch.sh:/watch.sh:ro
     environment:
       APP_HOST: localhost
@@ -94,17 +126,22 @@ services:
     working_dir: /var/www/uprzejmiedonosze.net/webapp
     volumes:
       - ../export:/var/www/uprzejmiedonosze.net/webapp
+      - ../config.dev.php:/var/www/uprzejmiedonosze.net/webapp/config.dev.php:ro
       - ./devroot/db:/var/www/uprzejmiedonosze.net/db
     env_file:
-      - .env.dev
+      - path: .env.dev
+        required: false
     depends_on:
       builder:
         condition: service_healthy
       firebase-emulator:
         condition: service_started
+      mailpit:
+        condition: service_started
       memcached:
         condition: service_started
     environment:
+      APP_ENV: dev
       APP_HOST: localhost
       APP_HTTPS: http
       FIREBASE_AUTH_EMULATOR_HOST: "firebase-emulator:9099"

--- a/services/firebase-mail-bridge/bridge.py
+++ b/services/firebase-mail-bridge/bridge.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Dev-only bridge: Firebase Auth Emulator -> SMTP (Mailpit).
+
+The Auth Emulator never sends real email; it only exposes generated OOB links
+(email sign-in, password reset, verification) at its REST endpoint. This poller
+picks up each new link and relays it as a real email into Mailpit, so dev gets a
+prod-like flow: enter email -> message lands in http://localhost:8025 -> click
+the link -> FirebaseUI completes sign-in.
+
+Stdlib only (urllib + smtplib) so it runs on a bare python:*-alpine image.
+"""
+import email.utils
+import html
+import json
+import os
+import smtplib
+import sys
+import time
+import urllib.error
+import urllib.request
+from email.message import EmailMessage
+
+EMULATOR_HOST = os.environ.get("EMULATOR_HOST", "firebase-emulator:9099")
+FIREBASE_PROJECT = os.environ.get("FIREBASE_PROJECT", "demo-project")
+SMTP_HOST = os.environ.get("BRIDGE_SMTP_HOST", "mailpit")
+SMTP_PORT = int(os.environ.get("BRIDGE_SMTP_PORT", "1025"))
+MAIL_FROM = os.environ.get("BRIDGE_MAIL_FROM", "no-reply@uprzejmiedonosze.net")
+POLL_INTERVAL = float(os.environ.get("BRIDGE_POLL_INTERVAL", "2"))
+
+OOB_URL = f"http://{EMULATOR_HOST}/emulator/v1/projects/{FIREBASE_PROJECT}/oobCodes"
+
+# requestType -> (subject, lead line). Falls back to a generic entry.
+TEMPLATES = {
+    "EMAIL_SIGNIN": ("Zaloguj się do uprzejmiedonosze.net", "Kliknij, aby się zalogować:"),
+    "PASSWORD_RESET": ("Reset hasła — uprzejmiedonosze.net", "Kliknij, aby zresetować hasło:"),
+    "VERIFY_EMAIL": ("Potwierdź adres e-mail", "Kliknij, aby potwierdzić adres e-mail:"),
+}
+
+
+def log(*args):
+    print("[fb-mail-bridge]", *args, file=sys.stderr, flush=True)
+
+
+def fetch_oob_codes():
+    with urllib.request.urlopen(OOB_URL, timeout=5) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    return data.get("oobCodes", [])
+
+
+def send_email(entry):
+    to_addr = entry.get("email")
+    link = entry.get("oobLink")
+    if not to_addr or not link:
+        log("skipping entry without email/oobLink:", entry)
+        return
+
+    subject, lead = TEMPLATES.get(
+        entry.get("requestType", ""),
+        ("Wiadomość z uprzejmiedonosze.net (dev)", "Kliknij w link:"),
+    )
+
+    msg = EmailMessage()
+    msg["From"] = MAIL_FROM
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg["Date"] = email.utils.formatdate(localtime=True)
+    msg["Message-ID"] = email.utils.make_msgid(domain="uprzejmiedonosze.net")
+    msg["X-UD-OOB-Request-Type"] = entry.get("requestType", "UNKNOWN")
+
+    msg.set_content(f"{lead}\n\n{link}\n\n--\nWysłane przez firebase-mail-bridge (dev).")
+    safe_link = html.escape(link, quote=True)
+    msg.add_alternative(
+        f"""<html><body style="font-family:sans-serif">
+  <p>{html.escape(lead)}</p>
+  <p><a href="{safe_link}" style="display:inline-block;padding:10px 18px;
+     background:#1565c0;color:#fff;text-decoration:none;border-radius:4px">
+     {html.escape(subject)}</a></p>
+  <p style="font-size:12px;color:#888;word-break:break-all">{safe_link}</p>
+  <hr><p style="font-size:11px;color:#aaa">Wysłane przez firebase-mail-bridge (dev).</p>
+</body></html>""",
+        subtype="html",
+    )
+
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=10) as smtp:
+        smtp.send_message(msg)
+    log(f"relayed {entry.get('requestType')} for {to_addr} -> {SMTP_HOST}:{SMTP_PORT}")
+
+
+def main():
+    log(f"polling {OOB_URL} every {POLL_INTERVAL}s, relaying to {SMTP_HOST}:{SMTP_PORT}")
+    seen = set()
+    while True:
+        try:
+            for entry in fetch_oob_codes():
+                code = entry.get("oobCode")
+                if not code or code in seen:
+                    continue
+                seen.add(code)
+                try:
+                    send_email(entry)
+                except Exception as err:  # noqa: BLE001 - keep the poller alive
+                    log("failed to relay:", err)
+                    seen.discard(code)  # retry next tick
+        except urllib.error.URLError as err:
+            log("emulator not reachable yet:", err)
+        except Exception as err:  # noqa: BLE001
+            log("poll error:", err)
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/webapp/watch.sh
+++ b/services/webapp/watch.sh
@@ -21,6 +21,7 @@ build_config_env() {
     printf '<?php\ndefine("HOST", "%s");\ndefine("TWIG_HASH", "%s");\ndefine("CSS_HASH", "%s");\ndefine("JS_HASH", "%s");\ndefine("HTTPS", "%s");\n' \
         "$APP_HOST" "$TWIG_HASH" "$CSS_HASH" "$JS_HASH" "$APP_HTTPS" \
         > export/config.env.php
+    [ -f config.dev.php ] && cp config.dev.php export/config.dev.php  # fallback if compose mount absent
 }
 
 build_static() {
@@ -34,6 +35,7 @@ build_static() {
     find src/api -maxdepth 1 -name '*.html' -exec cp {} export/public/api/ \;
     cp src/images-index.html export/
     [ -d src/img ] && cp -r src/img/. export/public/img/ || true
+    [ -f config.dev.php ] && cp config.dev.php export/config.dev.php  # fallback if compose mount absent
 }
 
 build_json() {

--- a/src/inc/config.php
+++ b/src/inc/config.php
@@ -18,47 +18,55 @@ $STOP_AGRESJI = \json\get('stop-agresji.json', 'StopAgresji');
 $LEVELS = \json\get('levels.json', 'Level');
 $BADGES = \json\get('badges.json');
 
-if (!getenv('APP_ENV') && is_file(__DIR__ . '/../config.prod.php')) {
+$_appEnv = getenv('APP_ENV');
+$_configDev = __DIR__ . '/../config.dev.php';
+// Dev bootstrap: config.dev.php defines fixture keys, Mailpit DSN, etc.
+// getenv() below only fills constants the file did not set (cannot override defines).
+// Opt-in on APP_ENV=dev only — an unset APP_ENV must never pull in dev config.
+if ($_appEnv === 'dev' && is_file($_configDev)) {
+    require $_configDev;
+} elseif (!getenv('APP_ENV') && is_file(__DIR__ . '/../config.prod.php')) {
     // Non-Docker deployment (quickfix rsync): config.prod.php generated from .env.prod at build time
     require __DIR__ . '/../config.prod.php';
-} else {
-define('SMTP_HOST',    getenv('SMTP_HOST')    ?: '');
-define('SMTP_USER',    getenv('SMTP_USER')    ?: '');
-define('EMAIL_SENDER', getenv('EMAIL_SENDER') ?: '');
-define('SMTP_PASS',    getenv('SMTP_PASS')    ?: '');
-define('SMTP_GMAIL',   getenv('SMTP_GMAIL')   ?: '');
-
-define('PLATERECOGNIZER_SECRET', getenv('PLATERECOGNIZER_SECRET') ?: '');
-define('OPEN_ALPR_SECRET_1',     getenv('OPEN_ALPR_SECRET_1')     ?: '');
-define('OPEN_ALPR_SECRET_2',     getenv('OPEN_ALPR_SECRET_2')     ?: '');
-define('MAPBOX_API_TOKEN',       getenv('MAPBOX_API_TOKEN')       ?: '');
-define('GOOGLE_MAPS_API_TOKEN',  getenv('GOOGLE_MAPS_API_TOKEN')  ?: '');
-define('PATRONITE_TOKEN',        getenv('PATRONITE_TOKEN')        ?: '');
-
-define('MAILER_DSN',            getenv('MAILER_DSN')            ?: '');
-define('MAILER_FROM',           getenv('MAILER_FROM')           ?: '');
-define('MAILER_WEBHOOK_SECRET', getenv('MAILER_WEBHOOK_SECRET') ?: '');
-define('MAILER_DSN_ALTER',      getenv('MAILER_DSN_ALTER')      ?: '');
-define('MAILER_FROM_ALTER',     getenv('MAILER_FROM_ALTER')     ?: '');
-
-define('CRYPTO_KEY', getenv('CRYPTO_KEY') ?: '');
-define('CRYPTO_IV',  getenv('CRYPTO_IV')  ?: '');
-define('CRYPTO_TAG', getenv('CRYPTO_TAG') ?: '');
-
-define('OPENAI_API_KEY',  getenv('OPENAI_API_KEY')  ?: '');
-define('GOOGLE_API_KEY',  getenv('GOOGLE_API_KEY')  ?: '');
-define('OPENAI_PROJECT',  getenv('OPENAI_PROJECT')  ?: '');
-
-define('MATOMO_SITE_ID',     (int)(getenv('MATOMO_SITE_ID') ?: 1));
-define('BACKEND_API_KEY',    getenv('BACKEND_API_KEY')    ?: '');
-define('CORS_ALLOWED_DOMAIN', getenv('CORS_ALLOWED_DOMAIN') ?: '');
-
-define('S3_KEY',      getenv('S3_KEY')      ?: '');
-define('S3_SECRET',   getenv('S3_SECRET')   ?: '');
-define('S3_BUCKET',   getenv('S3_BUCKET')   ?: '');
-define('S3_ENDPOINT', getenv('S3_ENDPOINT') ?: '');
-define('S3_REGION',   getenv('S3_REGION')   ?: '');
 }
+
+if (!defined('SMTP_HOST'))    define('SMTP_HOST',    getenv('SMTP_HOST')    ?: '');
+if (!defined('SMTP_USER'))    define('SMTP_USER',    getenv('SMTP_USER')    ?: '');
+if (!defined('EMAIL_SENDER')) define('EMAIL_SENDER', getenv('EMAIL_SENDER') ?: '');
+if (!defined('SMTP_PASS'))    define('SMTP_PASS',    getenv('SMTP_PASS')    ?: '');
+if (!defined('SMTP_GMAIL'))   define('SMTP_GMAIL',   getenv('SMTP_GMAIL')   ?: '');
+
+if (!defined('PLATERECOGNIZER_SECRET')) define('PLATERECOGNIZER_SECRET', getenv('PLATERECOGNIZER_SECRET') ?: '');
+if (!defined('OPEN_ALPR_SECRET_1'))     define('OPEN_ALPR_SECRET_1',     getenv('OPEN_ALPR_SECRET_1')     ?: '');
+if (!defined('OPEN_ALPR_SECRET_2'))     define('OPEN_ALPR_SECRET_2',     getenv('OPEN_ALPR_SECRET_2')     ?: '');
+if (!defined('MAPBOX_API_TOKEN'))       define('MAPBOX_API_TOKEN',       getenv('MAPBOX_API_TOKEN')       ?: '');
+if (!defined('GOOGLE_MAPS_API_TOKEN'))  define('GOOGLE_MAPS_API_TOKEN',  getenv('GOOGLE_MAPS_API_TOKEN')  ?: '');
+if (!defined('PATRONITE_TOKEN'))        define('PATRONITE_TOKEN',        getenv('PATRONITE_TOKEN')        ?: '');
+
+if (!defined('MAILER_DSN'))            define('MAILER_DSN',            getenv('MAILER_DSN')            ?: '');
+if (!defined('MAILER_FROM'))           define('MAILER_FROM',           getenv('MAILER_FROM')           ?: '');
+if (!defined('MAILER_WEBHOOK_SECRET')) define('MAILER_WEBHOOK_SECRET', getenv('MAILER_WEBHOOK_SECRET') ?: '');
+if (!defined('MAILER_DSN_ALTER'))      define('MAILER_DSN_ALTER',      getenv('MAILER_DSN_ALTER')      ?: '');
+if (!defined('MAILER_FROM_ALTER'))     define('MAILER_FROM_ALTER',     getenv('MAILER_FROM_ALTER')     ?: '');
+
+if (!defined('CRYPTO_KEY')) define('CRYPTO_KEY', getenv('CRYPTO_KEY') ?: '');
+if (!defined('CRYPTO_IV'))  define('CRYPTO_IV',  getenv('CRYPTO_IV')  ?: '');
+if (!defined('CRYPTO_TAG')) define('CRYPTO_TAG', getenv('CRYPTO_TAG') ?: '');
+
+if (!defined('OPENAI_API_KEY')) define('OPENAI_API_KEY', getenv('OPENAI_API_KEY') ?: '');
+if (!defined('GOOGLE_API_KEY')) define('GOOGLE_API_KEY', getenv('GOOGLE_API_KEY') ?: '');
+if (!defined('OPENAI_PROJECT')) define('OPENAI_PROJECT', getenv('OPENAI_PROJECT') ?: '');
+
+if (!defined('MATOMO_SITE_ID'))     define('MATOMO_SITE_ID',     (int)(getenv('MATOMO_SITE_ID') ?: 1));
+if (!defined('BACKEND_API_KEY'))    define('BACKEND_API_KEY',    getenv('BACKEND_API_KEY')    ?: '');
+if (!defined('CORS_ALLOWED_DOMAIN')) define('CORS_ALLOWED_DOMAIN', getenv('CORS_ALLOWED_DOMAIN') ?: '');
+
+if (!defined('S3_KEY'))      define('S3_KEY',      getenv('S3_KEY')      ?: '');
+if (!defined('S3_SECRET'))   define('S3_SECRET',   getenv('S3_SECRET')   ?: '');
+if (!defined('S3_BUCKET'))   define('S3_BUCKET',   getenv('S3_BUCKET')   ?: '');
+if (!defined('S3_ENDPOINT')) define('S3_ENDPOINT', getenv('S3_ENDPOINT') ?: '');
+if (!defined('S3_REGION'))   define('S3_REGION',   getenv('S3_REGION')   ?: '');
+unset($_appEnv, $_configDev);
 
 $_appHost = getenv('APP_HOST');
 if ($_appHost) {

--- a/src/inc/integrations/Mail.php
+++ b/src/inc/integrations/Mail.php
@@ -82,11 +82,14 @@ class Mail extends CityAPI {
                 $mailer->send($message);
             }
 
-        } catch (TransportExceptionInterface $error) {
+        } catch (\Throwable $error) {
             $application->setStatus('sending-failed', true);
             unset($application->sent);
             \app\save($application);
-            throw new Exception($error->getMessage(), 500, $error);
+            if ($error instanceof \Exception) {
+                throw $error;
+            }
+            throw new \Exception($error->getMessage(), 500, $error);
         } finally {
             \semaphore\release($application->id, "sendMail");
             \app\rmPdf($application);

--- a/src/inc/integrations/Mail.php
+++ b/src/inc/integrations/Mail.php
@@ -28,10 +28,6 @@ class Mail extends CityAPI {
             $to = $application->guessSMData()->email;
         }
 
-        $transport = Transport::fromDsn(SMTP_GMAIL . '://' . SMTP_USER . ':' . rawurlencode(SMTP_PASS) . '@' . SMTP_HOST);
-        
-        $mailer = new Mailer($transport);
-
         $subject = $application->getEmailSubject();
 
         $message = (new Email());
@@ -75,8 +71,16 @@ class Mail extends CityAPI {
             [$fileatt, $fileattname] = \app\toZip($application);
             $message->attachFromPath($fileatt, $fileattname);
 
-            if (!isDev())
+            $dryRun = isDev() && !MAILER_DSN;
+            if (!$dryRun) {
+                if (isDev()) {
+                    $transport = Transport::fromDsn(MAILER_DSN);
+                } else {
+                    $transport = Transport::fromDsn(SMTP_GMAIL . '://' . SMTP_USER . ':' . rawurlencode(SMTP_PASS) . '@' . SMTP_HOST);
+                }
+                $mailer = new Mailer($transport);
                 $mailer->send($message);
+            }
 
         } catch (TransportExceptionInterface $error) {
             $application->setStatus('sending-failed', true);
@@ -89,6 +93,7 @@ class Mail extends CityAPI {
             \app\rmZip($application);
         }
 
+        $application->syncToS3();
         return $application;
     }
 }

--- a/src/inc/integrations/MailGun.php
+++ b/src/inc/integrations/MailGun.php
@@ -82,16 +82,16 @@ class MailGun extends CityAPI {
             $application->sent->method = "MailGun";
             \app\save($application);
 
-            if (!isDev()) {
-                if ($this->alternate) {
-                    $transport = Transport::fromDsn(MAILER_DSN_ALTER);
-                } else {
-                    $transport = Transport::fromDsn(MAILER_DSN);
-                }
+            $dsn = $this->alternate ? MAILER_DSN_ALTER : MAILER_DSN;
+            $dryRun = isDev() && $dsn === '';
+            if (!$dryRun) {
+                $transport = Transport::fromDsn($dsn);
                 $mailer = new Mailer($transport);
                 $mailer->send($message);
-            } else {
-                logger("Sending app {$application->id} with MailGun");
+            }
+
+            if (isDev()) {
+                logger("Sending app {$application->id} with MailGun" . ($dryRun ? ' (dry-run)' : ''));
                 $application->setStatus('confirmed-waiting');
                 logger("Marking app {$application->id} as confirmed-waiting (sent)");
                 \app\save($application);

--- a/src/inc/store/Patronite.php
+++ b/src/inc/store/Patronite.php
@@ -38,7 +38,7 @@ enum PatronieStatus:string {
 
 
 function __get(PatronieStatus $status):array {
-    if (!defined("\\PATRONITE_TOKEN")) return [];
+    if (!defined("\\PATRONITE_TOKEN") || !\PATRONITE_TOKEN) return [];
     try {
         $result = \curl\request("https://patronite.pl/author-api/patrons/{$status->value}?with_notes=yes",
             [], "Patronite", array(


### PR DESCRIPTION
**Opis zmian:**
- Dodałem nowy serwis - Mailpit - w compose.yml - daje on lokalny podgląd wysłanych maili na localhost:8025.
- Dodałem nowy serwis - Firebase bridge - który wysyła maile z linkami z emulatora Firebase Auth (logowanie e-mail / reset hasła) do Mailpita, dzięki czemu lokalnie mamy flow logowania jak na produkcji, nie trzeba szukać linków w logach dockera.
- Przebudowa config.php - config.dev.php ładowany jest tylko przy APP_ENV=dev (a nie jak wcześniej, gdy env != prod i != staging), także dev-owy DSN Mailpita nie wycieknie na produkcję, zmieniłem domyślne ustawienia tak że aplikacja startuje bez problemów, a plik .env.dev jest opcjonalny.
- Pare drobnych optymalizacji, np by nie definiować zmiennych jako puste stringi, jeżeli te nie są ustawione

Podgląd wygenerowanego załącznika w Mailpit:
<img width="1512" height="751" alt="Screenshot 2026-06-26 at 20 50 29" src="https://github.com/user-attachments/assets/b055a861-a017-4388-a92e-a7d5e353279e" /> 

Podgląd mailii w Mailpit:
<img width="1512" height="720" alt="image" src="https://github.com/user-attachments/assets/25eca385-57d2-4acd-b3e9-14b5b90ee3f3" />
