### PR TITLE
Fix security issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ init-db-staging: ## Initialize staging SQLite database (run once on server)
 
 .PHONY: test
 test: ## Run phpunit tests in the builder container
-	@docker exec --env-file services/.env.dev -e APP_ENV=staging -e MEMCACHED_HOST=memcached -e TEST_DB=/tmp/run-test-db.sqlite builder sh -c "cp /tmp/test-db.sqlite /tmp/run-test-db.sqlite && ./vendor/bin/phpunit --display-deprecations tests"
+	@docker exec $(if $(wildcard services/.env.dev),--env-file services/.env.dev) -e APP_ENV=staging -e MEMCACHED_HOST=memcached -e TEST_DB=/tmp/run-test-db.sqlite builder sh -c "cp /tmp/test-db.sqlite /tmp/run-test-db.sqlite && ./vendor/bin/phpunit --display-deprecations tests"
 
 .PHONY: cypress-local
 cypress-local: ## Run Cypress tests against local dev environment

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,8 @@
   beStrictAboutOutputDuringTests="true"
   failOnRisky="true"
   failOnWarning="true"
+  executionOrder="random"
+  resolveDependencies="true"
   bootstrap="tests/bootstrap.php"
   cacheDirectory=".phpunit.cache">
   <php>

--- a/src/api/rest/index.php
+++ b/src/api/rest/index.php
@@ -199,9 +199,8 @@ $app->group('/api/rest/app', function (RouteCollectorProxy $group) { // APPLICAT
     });
 
     $group->get('/{appId}', function (Request $request, Response $response) {
-        $user = $request->getAttribute('user');
         $application = $request->getAttribute('application');
-    
+
         $twig = initBareTwig();
         $user = \user\current();
         $sex = ($user)? $user->getSex(): SEXSTRINGS['?'];
@@ -211,16 +210,12 @@ $app->group('/api/rest/app', function (RouteCollectorProxy $group) { // APPLICAT
                 'sex' => $sex
             ]
         ]);
-    
+
         $application->formattedText = json_decode($appJson);
-    
-        if ($application->email !== $user->getEmail()) {
-            $application->user = '';
-        }
-    
+
         $response->getBody()->write(json_encode($application));
         return $response;
-    })  ->add(new AppMiddleware(failOnWrongOwnership: false));
+    })  ->add(new AppMiddleware());
 
     $group->post('/{appId}', function (Request $request, Response $response, $args) {
         $appId = $args['appId'];

--- a/src/inc/API.php
+++ b/src/inc/API.php
@@ -28,7 +28,7 @@ function updateApplication(
 ): Application {
 
     if ($application->email !== $user->getEmail()) {
-        throw new ForbiddenException("Odmawiam aktualizacji zgłoszenia '{$application->id}' przez '{$user->getEmail()}'");
+        throw new ForbiddenException("Nie posiadasz zgłoszenia o ID {$application->id}");
     }
 
     if (!$application->isEditable()) {
@@ -99,8 +99,11 @@ function updateApplication(
  * Sets application status.
  */
 function setStatus(string $status, string $appId, User $user): Application {
-    $application = \semaphore\withLock($appId, "setStatus", function () use ($appId, $status) {
+    $application = \semaphore\withLock($appId, "setStatus", function () use ($appId, $status, $user) {
         $application = \app\get($appId);
+        if (!$application->isAppOwner($user)) {
+            throw new ForbiddenException("Nie posiadasz zgłoszenia o ID {$appId}");
+        }
         $application->setStatus($status);
         return \app\save($application);
     });
@@ -123,6 +126,9 @@ function setStatus(string $status, string $appId, User $user): Application {
  */
 function sendApplication(string $appId, User $user): Application {
     $application = \app\get($appId);
+    if (!$application->isAppOwner($user)) {
+        throw new ForbiddenException("Nie posiadasz zgłoszenia o ID {$appId}");
+    }
     CityAPI::checkApplication($application);
     $sm = $application->guessSMData();
     $api = new $sm->api;

--- a/src/inc/dataclasses/Application.php
+++ b/src/inc/dataclasses/Application.php
@@ -250,14 +250,14 @@ class Application extends JSONObject implements \JsonSerializable {
         global $STATUSES;
 
         if(!array_key_exists($status, $STATUSES)){
-            throw new Exception("Odmawiam ustawienia statusu na '$status'");
+            throw new Exception("Nieznany status '$status'");
         }
         if($status == $this->status){
             logger("Zmiana statusu na ten sam ($status) dla zgłoszenia {$this->id}");
             return;
         }elseif(!in_array($status, $this->getStatus()->allowed)){
             if (!$force)
-                throw new Exception("Odmawiam zmiany statusu z '{$this->status}' na '$status' dla zgłoszenia '{$this->id}'");
+                throw new Exception("Niedozwolona zmiana statusu z '{$this->status}' na '$status' dla zgłoszenia '{$this->id}'");
         }
         if(!isset($this->statusHistory))
             $this->statusHistory = [];
@@ -413,6 +413,10 @@ class Application extends JSONObject implements \JsonSerializable {
 
     public function getLatexSafeComment(){
         return $this->getLatexSafe($this->userComment);
+    }
+
+    public function getLatexSafePlateId() {
+        return $this->getLatexSafe($this->carInfo->plateId ?? '');
     }
 
     public function getLatexSafeAddress() {
@@ -688,7 +692,7 @@ class Application extends JSONObject implements \JsonSerializable {
         $showImage = $showImage || $this->statements->gallery;
         
         // hide photos with faces
-        $showImage = $showImage && ($app->faces->count ?? 0) == 0;
+        $showImage = $showImage && ($this->faces->count ?? 0) == 0;
 
         // app owner can always see his photos
         $showImage = $showImage || $this->isAppOwner($whoIsWathing);

--- a/src/inc/handlers/ApplicationHandler.php
+++ b/src/inc/handlers/ApplicationHandler.php
@@ -6,6 +6,7 @@ use app\Application;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Exception\HttpForbiddenException;
+use Slim\Exception\HttpNotFoundException;
 
 /**
  * @SuppressWarnings(PHPMD.StaticAccess)
@@ -195,8 +196,11 @@ class ApplicationHandler extends AbstractHandler {
         unset($_SESSION['newAppId']);
         $user = $request->getAttribute('user');
 
-        $result = \semaphore\withLock($appId, "finish", function () use ($appId, $STATUSES) {
+        $result = \semaphore\withLock($appId, "finish", function () use ($appId, $STATUSES, $user, $request) {
             $application = \app\get($appId);
+            if (!$application->isAppOwner($user)) {
+                throw new HttpNotFoundException($request, "Nie posiadasz zgłoszenia o ID {$appId}");
+            }
             $status = $STATUSES[$application->status];
             if(!$status->editable) {
                 logger("Ponowny POST na /dziekujemy.html dla zgłoszenia {$application->number} w statusie {$status->name}");
@@ -307,8 +311,12 @@ class ApplicationHandler extends AbstractHandler {
     }
 
     public function applicationShortHtml(Request $request, Response $response, $args) {
+        $user = $request->getAttribute('user');
         $appId = $args['appId'];
         $application = \app\get($appId);
+
+        if (!$application->isAppOwner($user))
+            throw new HttpNotFoundException($request, "Nie posiadasz zgłoszenia o ID {$appId}");
 
         return AbstractHandler::renderHtml($request, $response, '_application-short-details', [
             'appActionButtons' => true,

--- a/src/inc/handlers/SessionApiHandler.php
+++ b/src/inc/handlers/SessionApiHandler.php
@@ -32,7 +32,7 @@ class SessionApiHandler extends AbstractHandler {
      */
     public function validateUser(Request $request, Response $response, $args): Response {
         $apiKey = $request->getHeaderLine('X-API-Key');
-        if (empty($apiKey) || $apiKey !== BACKEND_API_KEY) {
+        if (empty($apiKey) || !hash_equals((string) BACKEND_API_KEY, $apiKey)) {
             throw new HttpForbiddenException($request, "Invalid or missing API key");
         }
         
@@ -147,8 +147,11 @@ class SessionApiHandler extends AbstractHandler {
         $appId = $args['appId'];
         $status = $args['status'];
         $user = $request->getAttribute('user');
-        $application = setStatus($status, $appId, $user);
-        $this->checkOwnership($request, $application);
+        try {
+            $application = setStatus($status, $appId, $user);
+        } catch (ForbiddenException $e) {
+            throw new HttpForbiddenException($request, $e->getMessage(), $e);
+        }
         return $this->renderJson($response, array(
             "status" => "OK",
             "patronite" => $application->patronite
@@ -164,7 +167,7 @@ class SessionApiHandler extends AbstractHandler {
             $fields = json_decode($request->getBody()->getContents(), true, flags: JSON_THROW_ON_ERROR);
             foreach ($fields as $field => $value) {
                 match ($field) {
-                    'externalId' => $application->externalId = $value,
+                    'externalId' => $application->externalId = mb_substr(trim((string) $value), 0, 100),
                     'privateComment' => $application->privateComment = $value,
                     default => throw new HttpForbiddenException($request, 'Pole ' . $field . ' nie może być edytowane'),
                 };
@@ -189,6 +192,8 @@ class SessionApiHandler extends AbstractHandler {
         try {
             $application = sendApplication($appId, $user);
             \telemetry\log('report_sent', $appId);
+        } catch (ForbiddenException $e) {
+            throw new HttpForbiddenException($request, $e->getMessage(), $e);
         } catch (NotSendableException $e) {
             return $this->renderJson($response->withStatus(409), array(
                 "error" => $e->getMessage()

--- a/src/inc/store/RecydywaStore.php
+++ b/src/inc/store/RecydywaStore.php
@@ -110,7 +110,10 @@ function lastTicket(array $recydywa): string {
         $by = $lastTicket->owner ? 'Np. twoje zgłoszenie' : 'Np. zgłoszenie innej osoby';
     }
     
-    $number = $lastTicket->number . ($lastTicket->externalId ? " (" . strtoupper($lastTicket->externalId ) . ")" : '');
+    $externalIdSuffix = $lastTicket->externalId
+        ? " (" . htmlspecialchars(strtoupper((string) $lastTicket->externalId), ENT_QUOTES) . ")"
+        : '';
+    $number = htmlspecialchars((string) $lastTicket->number, ENT_QUOTES) . $externalIdSuffix;
     $date = formatDateTime($lastTicket->date, 'd.MM.y');
     
     $sm = \SM::resolve($lastTicket->smCity, $lastTicket->stopAgresji);

--- a/src/templates/_application.tex.twig
+++ b/src/templates/_application.tex.twig
@@ -32,7 +32,7 @@
 \end{center}
 
 W dniu {{ app.getDate }} {{ app.getDateTimeDivider }} {{ app.getTime }} {{ app.guessUserSex.bylam }}
-świadkiem wykroczenia kierowcy pojazdu o nr. rejestracyjnym\texttt{ {{ app.carInfo.plateId }} }w~okolicy adresu
+świadkiem wykroczenia kierowcy pojazdu o nr. rejestracyjnym\texttt{ {{ app.getLatexSafePlateId|raw }} }w~okolicy adresu
 \href{{ mapUrl|raw -}}{ {{ app.getLatexSafeAddress|raw -}} }\footnote{\noindent
 Adres oraz zdjęcia można ,,kliknąć'' aby uzyskać więcej informacji.}.
 {{ app.getCategory.formal }} 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace UprzejmieDonosze\Tests;
+
+use app\Application;
+use user\User;
+
+// API.php (free functions setStatus/sendApplication) is not pulled in by
+// include.php, so load it explicitly.
+require_once(__DIR__ . '/../export/inc/API.php');
+
+/**
+ * Access-control behaviour of the legacy session-API operations in
+ * src/inc/API.php. A user must never be able to mutate or send a report that
+ * belongs to someone else.
+ */
+class ApiTest extends DatabaseTestCase
+{
+    private $appJson = '{"date":"2019-03-31T13:06:23","id":"66610107-29dd-4392-8bae-83c71426d844","added":"2019-04-14T13:22:48","user":{"email":"e@nieradka.net","name":"Ud Developer","number":2,"exposeData":false,"msisdn":"","address":"Rynek 99-120, Piątek"},"status":"confirmed","category":8,"statements":{"witness":false},"statusHistory":{"2019-04-14T13:27:05":{"old":"draft","new":"ready"},"2019-04-14T13:27:11":{"old":"ready","new":"confirmed"}},"contextImage":{"url":"cdn\/ce883f8d-2f8d-4048-8725-76a2777b2811.jpg","thumb":"cdn\/ce883f8d-2f8d-4048-8725-76a2777b2811,t.jpg"},"carImage":{"url":"cdn\/d74a29f5-9cde-4370-a8f0-fcc1dc9bcd12.jpg","thumb":"cdn\/d74a29f5-9cde-4370-a8f0-fcc1dc9bcd12,t.jpg"},"carInfo":{"plateId":"ZS2450C","plateIdFromImage":"ZS2450C","brand":"Audi","plateImage":"cdn\/d74a29f5-9cde-4370-a8f0-fcc1dc9bcd12,p.jpg","recydywa":0},"dtFromPicture":true,"address":{"address":"aleja Papieża Jana Pawła II 36, Szczecin","city":"Szczecin","voivodeship":"zachodniopomorskie","lat":53.43474358333333,"lng":14.545931694444445},"smCity":"szczecin","userComment":"","number":"UD\/2\/2","comments":[],"extensions":[],"seq":2,"inexactHour":true,"version":"2.3.0"}';
+
+    /**
+     * Build a User whose getEmail() returns $email (User reads it from session).
+     */
+    private function makeUser(string $email): User
+    {
+        $_SESSION['user_email'] = $email;
+        $_SESSION['user_id'] = crc32($email);
+        return new User();
+    }
+
+    /**
+     * Persist a fresh 'confirmed' report owned by $ownerEmail under id $id.
+     */
+    private function seedApp(string $ownerEmail, string $id): void
+    {
+        $this->makeUser($ownerEmail); // owner session for encryption
+        $app = Application::withJson($this->appJson, $ownerEmail);
+        $app->id = $id;
+        \app\save($app);
+    }
+
+    // ── changing a report's status ────────────────────────────────────────────
+
+    public function testSetStatusRejectsNonOwner(): void
+    {
+        $id = 'apitest-status-reject';
+        $this->seedApp('owner-status@example.com', $id);
+        $attacker = $this->makeUser('attacker-status@example.com');
+
+        try {
+            \setStatus('confirmed-waiting', $id, $attacker);
+            $this->fail('Non-owner was allowed to change report status');
+        } catch (\ForbiddenException $e) {
+            $this->assertStringContainsString($id, $e->getMessage());
+        }
+
+        // The report must NOT have been mutated before the ownership check.
+        $this->assertEquals('confirmed', \app\get($id)->status);
+    }
+
+    public function testSetStatusAllowsOwner(): void
+    {
+        $id = 'apitest-status-ok';
+        $ownerEmail = 'owner-status-ok@example.com';
+        $this->seedApp($ownerEmail, $id);
+        $owner = $this->makeUser($ownerEmail);
+
+        try {
+            \setStatus('confirmed-waiting', $id, $owner);
+        } catch (\ForbiddenException $e) {
+            $this->fail('Owner was incorrectly denied: ' . $e->getMessage());
+        } catch (\Throwable $e) {
+            // The ownership gate + status write happen inside the lock; the
+            // post-lock badge stats reach Patronite over the network, which is
+            // unavailable in the test env (same as the skipped S3 paths).
+        }
+
+        // Owner passed the gate and the status was actually persisted.
+        $this->assertEquals('confirmed-waiting', \app\get($id)->status);
+    }
+
+    // ── sending a report to the authorities ───────────────────────────────────
+
+    public function testSendApplicationRejectsNonOwner(): void
+    {
+        $id = 'apitest-send-reject';
+        $this->seedApp('owner-send@example.com', $id);
+        $attacker = $this->makeUser('attacker-send@example.com');
+
+        // Ownership is checked before CityAPI::checkApplication and any network
+        // send, so a non-owner is rejected without side effects.
+        $this->expectException(\ForbiddenException::class);
+        \sendApplication($id, $attacker);
+    }
+}

--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace UprzejmieDonosze\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base class that isolates every test from the others.
+ *
+ *  - $_SESSION is cleared before and after each test. The app reads the current
+ *    user's identity straight from the session superglobal, so a leaked session
+ *    would otherwise let one test impersonate another's user.
+ *  - All DB work runs inside a transaction that is rolled back in tearDown, so
+ *    rows never leak into the shared SQLite test database between tests.
+ *
+ * The store exposes a single shared PDO connection (\store\store()) and no
+ * production code opens its own transaction (semaphore locks live in memcached,
+ * not SQLite), so a per-test BEGIN/ROLLBACK fully contains every write.
+ */
+abstract class DatabaseTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_SESSION = [];
+        \store\store()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $db = \store\store();
+        if ($db->inTransaction()) {
+            $db->rollBack();
+        }
+        $_SESSION = [];
+        parent::tearDown();
+    }
+}

--- a/tests/Dataclasses/ApplicationTest.php
+++ b/tests/Dataclasses/ApplicationTest.php
@@ -2,12 +2,12 @@
 
 namespace UprzejmieDonosze\Tests\Dataclasses;
 
-use PHPUnit\Framework\TestCase;
 use app\Application;
 use Error;
 use user\User;
+use UprzejmieDonosze\Tests\DatabaseTestCase;
 
-class ApplicationTest extends TestCase
+class ApplicationTest extends DatabaseTestCase
 {
     private $appJson = '{"date":"2019-03-31T13:06:23","id":"66610107-29dd-4392-8bae-83c71426d844","added":"2019-04-14T13:22:48","user":{"email":"e@nieradka.net","name":"Ud Developer","number":2,"exposeData":false,"msisdn":"","address":"Rynek 99-120, Pi\u0105tek"},"status":"confirmed","category":8,"statements":{"witness":false},"statusHistory":{"2019-04-14T13:27:05":{"old":"draft","new":"ready"},"2019-04-14T13:27:11":{"old":"ready","new":"confirmed"}},"contextImage":{"url":"cdn\/ce883f8d-2f8d-4048-8725-76a2777b2811.jpg","thumb":"cdn\/ce883f8d-2f8d-4048-8725-76a2777b2811,t.jpg"},"carImage":{"url":"cdn\/d74a29f5-9cde-4370-a8f0-fcc1dc9bcd12.jpg","thumb":"cdn\/d74a29f5-9cde-4370-a8f0-fcc1dc9bcd12,t.jpg"},"carInfo":{"plateId":"ZS2450C","plateIdFromImage":"ZS2450C","brand":"Audi","plateImage":"cdn\/d74a29f5-9cde-4370-a8f0-fcc1dc9bcd12,p.jpg","recydywa":0},"dtFromPicture":true,"address":{"address":"aleja Papie\u017ca Jana Paw\u0142a II 36, Szczecin","city":"Szczecin","voivodeship":"zachodniopomorskie","lat":53.43474358333333,"lng":14.545931694444445},"smCity":"szczecin","userComment":"","number":"UD\/2\/2","comments":[],"extensions":[],"seq":2,"inexactHour":true,"version":"2.3.0"}';
     private $email = 'e@nieradka.net';
@@ -86,12 +86,12 @@ class ApplicationTest extends TestCase
 
         $this->assertThrowsException(function() use ($app) {
             $app->setStatus('submitted');
-        }, \Exception::class, "Odmawiam ustawienia statusu na 'submitted'");
+        }, \Exception::class, "Nieznany status 'submitted'");
         $this->assertEquals(1, sizeof($app->statusHistory));
 
         $this->assertThrowsException(function() use ($app) {
             $app->setStatus('sending');
-        }, \Exception::class, "Odmawiam zmiany statusu z 'ready' na 'sending' dla zgłoszenia '{$app->id}'");
+        }, \Exception::class, "Niedozwolona zmiana statusu z 'ready' na 'sending' dla zgłoszenia '{$app->id}'");
         $this->assertEquals(1, sizeof($app->statusHistory));
     }
 
@@ -148,6 +148,24 @@ class ApplicationTest extends TestCase
         $this->assertEquals(1, $app->getRevision());
     }
 
+    // ── LaTeX escaping of plateId in the PDF template ─────────────────────────
+
+    public function testGetLatexSafePlateIdNeutralisesInjection()
+    {
+        $app = Application::withJson($this->appJson, $this->email);
+        $app->carInfo->plateId = '}\input{/etc/passwd}';
+
+        $this->assertEquals('\} input\{/etc/passwd\}', $app->getLatexSafePlateId());
+    }
+
+    public function testGetLatexSafePlateIdPreservesNormalPlate()
+    {
+        $app = Application::withJson($this->appJson, $this->email);
+        $app->carInfo->plateId = 'ZS2450C';
+
+        $this->assertEquals('ZS2450C', $app->getLatexSafePlateId());
+    }
+
     public function testIsAppOwner()
     {
         $_SESSION['user_email'] = 'test1@example.com';
@@ -159,6 +177,32 @@ class ApplicationTest extends TestCase
 
         $_SESSION['user_email'] = 'test2@example.com';
         $this->assertFalse($app->isAppOwner(new User()));
+    }
+
+    // ── Face-hiding privacy gate (regression for the $app/$this typo) ──────────
+
+    public function testCanImageBeShownHidesPhotosWithFacesFromNonOwners()
+    {
+        $app = Application::withJson($this->appJson, $this->email);
+        $app->statements->gallery = false; // sharing comes from $canShareRecydywa below
+
+        // A non-owner viewer.
+        $_SESSION['user_email'] = 'attacker@example.com';
+        $viewer = new User();
+        $this->assertFalse($app->isAppOwner($viewer));
+
+        // A shared photo that contains a detected face must NOT be shown to a non-owner.
+        $app->faces = (object) ['count' => 1];
+        $this->assertFalse($app->canImageBeShown($viewer, true));
+
+        // The same shared photo without faces IS shown.
+        $app->faces = (object) ['count' => 0];
+        $this->assertTrue($app->canImageBeShown($viewer, true));
+
+        // The owner always sees their own photo, even with faces.
+        $app->faces = (object) ['count' => 1];
+        $_SESSION['user_email'] = $this->email;
+        $this->assertTrue($app->canImageBeShown(new User(), true));
     }
 
     public function testEncode()

--- a/tests/Dataclasses/UserTest.php
+++ b/tests/Dataclasses/UserTest.php
@@ -4,10 +4,10 @@ namespace UprzejmieDonosze\Tests\Dataclasses;
 
 use Exception;
 use MissingParamException;
-use PHPUnit\Framework\TestCase;
 use user\User;
+use UprzejmieDonosze\Tests\DatabaseTestCase;
 
-class UserTest extends TestCase
+class UserTest extends DatabaseTestCase
 {
     public function testIsRegistered()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,12 +5,15 @@ define('DB_FILENAME', getenv('TEST_DB') ?: __DIR__ . '/../services/devroot/db/st
 
 require(__DIR__ . '/../export/inc/include.php');
 require(__DIR__ . '/../export/inc/Twig.php');
+require_once(__DIR__ . '/DatabaseTestCase.php');
 
 $GLOBALS['STATUSES'] = $STATUSES;
 $GLOBALS['SM_ADDRESSES'] = $SM_ADDRESSES;
 $GLOBALS['POLICE_ADDRESSES'] = $POLICE_ADDRESSES;
 $GLOBALS['STOP_AGRESJI'] = $STOP_AGRESJI;
 $GLOBALS['CATEGORIES'] = $CATEGORIES;
+$GLOBALS['LEVELS'] = $LEVELS;
+$GLOBALS['BADGES'] = $BADGES;
 $GLOBALS['cache'] = $cache;
 $_SERVER['HTTP_USER_AGENT'] = 'PHPUnit';
 $_SESSION = [];

--- a/tests/store/RecydywaStoreTest.php
+++ b/tests/store/RecydywaStoreTest.php
@@ -2,20 +2,21 @@
 
 namespace UprzejmieDonosze\Tests\Store;
 
-require_once __DIR__ . '/../../export/inc/store/index.php';
 require_once __DIR__ . '/../../export/inc/integrations/Tumblr.php';
 
 use app\Application;
-use PHPUnit\Framework\TestCase;
 use user\User;
+use UprzejmieDonosze\Tests\DatabaseTestCase;
 
-class RecydywaStoreTest extends TestCase
+class RecydywaStoreTest extends DatabaseTestCase
 {
     private function getApp(): Application
     {
         $appJson = '{"date":"2019-03-31T13:06:23","id":"66610107-29dd-4392-8bae-83c71426d844","added":"2019-04-14T13:22:48","user":{"email":"e@nieradka.net","name":"Ud Developer","exposeData":false,"msisdn":"","address":"Rynek 99-120, Pi\u0105tek"},"status":"confirmed","category":8,"statusHistory":{"2019-04-14T13:27:05":{"old":"draft","new":"ready"},"2019-04-14T13:27:11":{"old":"ready","new":"confirmed"}},"contextImage":{"url":"cdn\/ce883f8d-2f8d-4048-8725-76a2777b2811.jpg","thumb":"cdn\/ce883f8d-2f8d-4048-8725-76a2777b2811,t.jpg"},"carImage":{"url":"cdn\/d74a29f5-9cde-4370-a8f0-fcc1dc9bcd12.jpg","thumb":"cdn\/d74a29f5-9cde-4370-a8f0-fcc1dc9bcd12,t.jpg"},"carInfo":{"plateId":"ZS2450C","plateIdFromImage":"ZS2450C","brand":"Audi","plateImage":"cdn\/d74a29f5-9cde-4370-a8f0-fcc1dc9bcd12,p.jpg","recydywa":0},"dtFromPicture":true,"address":{"address":"aleja Papie\u017ca Jana Paw\u0142a II 36, Szczecin","city":"Szczecin","voivodeship":"zachodniopomorskie","lat":53.43474358333333,"lng":14.545931694444445},"smCity":"szczecin","userComment":"","number":"UD\/2\/2","comments":[],"extensions":[],"seq":2,"inexactHour":true,"version":"2.3.0"}';
         $email = 'e@nieradka.net';
+        // Session is reset per test by DatabaseTestCase, so set up our own.
         $_SESSION['user_email'] = $email;
+        $_SESSION['user_id'] = 1;
         $app = Application::withJson($appJson, $email);
         $app->initStatements();
         $app->setStatus('sending');
@@ -63,6 +64,24 @@ class RecydywaStoreTest extends TestCase
         self::assertIsObject($detailed);
         self::assertIsArray($detailed->apps);
         self::assertEquals(1, count($detailed->apps));
+    }
+
+    public function testLastTicketEscapesMaliciousExternalId(): void
+    {
+        $apps = [new \JSONObject([
+            'status' => 'confirmed-fined',
+            'externalId' => '<img src=x onerror=alert(document.cookie)>',
+            'owner' => true,
+            'smCity' => 'szczecin',
+            'stopAgresji' => false,
+            'date' => '2019-03-31T13:06:23',
+            'number' => 'UD/2/2',
+            'addedToGallery' => null,
+        ])];
+
+        $html = \recydywa\lastTicket($apps);
+
+        self::assertStringContainsString('UD/2/2 (&lt;IMG SRC=X ONERROR=ALERT(DOCUMENT.COOKIE)&gt;)', $html);
     }
 
     public function testAddToGallery(): void


### PR DESCRIPTION
# Opis Zmian

## Poprawione
- `GET /api/rest/app/{appId}` zwracał dowolnemu użytkownikowi cudze zgłoszenie (e-mail, numer rejestracyjny, zdjęcia, numer). Wymuszone sprawdzanie właściciela w `AppMiddleware`.
- `finish()` pozwalał sfinalizować dowolnemu użytkownikowu cudze zgłoszenie. Dodano sprawdzanie właściciela (`isAppOwner`).
- Możliwy XSS poprzez pole `externalId` w okienku recydywy.
- `canImageBeShown` korzystało z niezdefiniowanej zmiennej `$app`, więc zdjęcia zawsze się pokazywały. Zmiana `$app` na `$this`
- sprawdzanie właściciela w `applicationShortHtml`
- klucz `BACKEND_API_KEY` jest teraz porównywany bezpiecznie poprzez metodę (hash_equals)
- zwracanie 403 zamiast 500 w `setStatus`/`sendApplication`, ekranowanie numeru rejestracyjnego w PDF.

## Porządki
- Komunikaty „Odmawiam…" zastąpione bardziej zrozumiałymi: „Nie posiadasz zgłoszenia o ID …", „Nieznany status", „Niedozwolona zmiana statusu"
- Naprawiłem "make test" dla gołego repo (wcześniej wymagało istnienia .env.dev którego domyślnie nie ma)
- Dodałem nowe testy na w/w zmiany
- Dodałem nową klasę abstrakcyjną `DatabaseTestCase` która czyści bazę danych po każdym teście i je izoluje- wcześniej, jeżeli testy były wykonane w innej kolejności niż domyślna, nie przechodziły.