### PR TITLE
MCP: set_report_notes tool (private case number + note)

### DIFF
--- a/API.md
+++ b/API.md
@@ -156,11 +156,12 @@ Streamable HTTP MCP endpoint. Requires an OAuth 2.1 bearer access token (see bel
 missing/invalid token it returns `401` with a `WWW-Authenticate: Bearer resource_metadata="…"`
 header pointing at the protected-resource metadata.
 
-The server is **read + record-outcome only**: it lists/reads reports and records the
-authority's response. Creating reports, editing their content, saving free-text notes, and
-fetching binary assets (images/PDF/ZIP) are intentionally out of scope for now. Tools reject
-unknown arguments (`additionalProperties: false`) rather than silently dropping them, and
-domain failures come back as readable tool errors (e.g. an illegal status transition or an
+The server lets an assistant read reports, record the authority's response
+(`update_report_status`), and save a report's **private** annotations — the case number and a
+private note (`set_report_notes`). Creating reports, editing the report content that is sent to
+authorities, and fetching binary assets (images/PDF/ZIP) are intentionally out of scope for now.
+Tools reject unknown arguments (`additionalProperties: false`) rather than silently dropping them,
+and domain failures come back as readable tool errors (e.g. an illegal status transition or an
 unknown report id), not opaque internal errors.
 
 Tools:
@@ -173,6 +174,9 @@ Tools:
     recordable outcomes: `confirmed-sm`, `confirmed-fined`, `confirmed-instructed`,
     `confirmed-ignored`, `confirmed-complaint`, `archived`). The transition is validated by the
     domain layer.
+  * `set_report_notes` — scope `reports:notes:write`. Params: `reportId`, and at least one of
+    `caseNumber` (authority case number) / `privateNote`. Both are private to the user and are
+    never sent to the authorities; each given value overwrites the current one.
 
 Every returned report expands its category into `categoryInfo` (`id`, `title`, `formal` wording,
 `law`, `fine` in PLN, `demeritPoints`) alongside the raw `category` number, and its recipient
@@ -187,7 +191,8 @@ clients use mainly for validation).
 
 Authorization-code grant with PKCE (S256), refresh tokens, and Dynamic Client Registration.
 Tokens are opaque (stored as SHA-256 hashes), audience-bound to the `/mcp` resource. Scopes:
-`reports:read`, `reports:status:write`. The consent step reuses the existing Firebase login.
+`reports:read`, `reports:status:write`, `reports:notes:write`. The consent step reuses the
+existing Firebase login.
 
 ### GET `/.well-known/oauth-authorization-server`
 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ Users review and revoke connected clients at **`/mcp`** (`/polaczone-aplikacje.h
 | `list_reports` | `reports:read` | list the user's reports (`all` excludes drafts; `allWithDrafts` includes them) |
 | `get_report` | `reports:read` | fetch one report by id |
 | `update_report_status` | `reports:status:write` | record the authority's response |
+| `set_report_notes` | `reports:notes:write` | save a private case number / note (never sent to authorities) |
 
-The surface is deliberately **read + record-outcome only** — creating reports, editing their
-content, saving free-text notes, and downloading binary assets (images/PDF/ZIP) are out of
-scope for now.
+Creating reports, editing the report content sent to authorities, and downloading binary assets
+(images/PDF/ZIP) are out of scope for now.
 
 Tokens are **opaque** (stored hashed, instantly revocable, audience-bound to `/mcp`);
 access tokens live 1h, refresh tokens 30d (sliding). Code: `src/api/mcp/` (server),

--- a/src/inc/mcp/McpServerFactory.php
+++ b/src/inc/mcp/McpServerFactory.php
@@ -109,6 +109,29 @@ function buildServer(): Server {
         'additionalProperties' => false,
     ];
 
+    // Input for set_report_notes. Both annotations are private to the user and
+    // never sent to the authorities; at least one must be provided.
+    $notesInputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'reportId' => [
+                'type' => 'string',
+                'description' => 'The report id.',
+            ],
+            'caseNumber' => [
+                'type' => 'string',
+                'description' => 'Authority (city guard / police) case number, e.g. "RSOW 123/24". '
+                    . 'Private to the user; not sent to anyone.',
+            ],
+            'privateNote' => [
+                'type' => 'string',
+                'description' => 'A free-text private note. Private to the user; not sent to anyone.',
+            ],
+        ],
+        'required' => ['reportId'],
+        'additionalProperties' => false,
+    ];
+
     return Server::builder()
         ->setServerInfo(
             'Uprzejmie Donoszę',
@@ -117,8 +140,9 @@ function buildServer(): Server {
         )
         ->setInstructions(
             'Browse the signed-in user\'s reports (zgłoszenia) with list_reports, '
-            . 'fetch one with get_report, and record the authority\'s response with '
-            . 'update_report_status. Each report has a `status` id (see the legend below) '
+            . 'fetch one with get_report, record the authority\'s response with '
+            . 'update_report_status, and save a private case number or note with '
+            . 'set_report_notes. Each report has a `status` id (see the legend below) '
             . 'and a categoryInfo object (the violation type, its formal wording and legal '
             . 'basis). Use the Polish status labels when talking to the user, and only set a '
             . 'status the current one is allowed to move to.'
@@ -160,6 +184,21 @@ function buildServer(): Server {
                 openWorldHint: false
             ),
             inputSchema: $updateInputSchema,
+            outputSchema: $reportSchema
+        )
+        ->addTool(
+            [$tools, 'setReportNotes'],
+            'set_report_notes',
+            description: 'Set private annotations on one of the signed-in user\'s reports: the '
+                . 'authority case number and/or a free-text note. Both are private to the user '
+                . 'and never sent to anyone. Requires the reports:notes:write scope.',
+            annotations: new ToolAnnotations(
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            ),
+            inputSchema: $notesInputSchema,
             outputSchema: $reportSchema
         )
         ->build();

--- a/src/inc/mcp/ReportMcpTools.php
+++ b/src/inc/mcp/ReportMcpTools.php
@@ -126,4 +126,54 @@ final class ReportMcpTools {
 
         return $this->enrich($application);
     }
+
+    /**
+     * Set the private annotations on one of the signed-in user's reports: the
+     * authority case number and/or a free-text note. Both are private to the
+     * user and are never sent to the authorities (they mirror the "NUMER SPRAWY"
+     * and "UWAGI" fields). At least one must be provided; each given value
+     * overwrites the current one.
+     *
+     * @param string      $reportId    The report id.
+     * @param string|null $caseNumber  Authority (SM/Police) case number, e.g. "RSOW 123/24".
+     * @param string|null $privateNote Free-text private note.
+     * @return array The updated report.
+     */
+    public function setReportNotes(string $reportId, ?string $caseNumber = null, ?string $privateNote = null): array {
+        McpIdentity::requireScope('reports:notes:write');
+        $user = McpIdentity::currentUser();
+
+        if ($caseNumber === null && $privateNote === null) {
+            throw new \Mcp\Exception\ToolCallException('Provide caseNumber and/or privateNote.');
+        }
+
+        $updated = \semaphore\withLock($reportId, 'mcpSetNotes', function () use ($reportId, $user, $caseNumber, $privateNote) {
+            // \app\get throws (rather than returning null) for an unknown id;
+            // surface it as a readable "not found" instead of an opaque error.
+            // ($e is chained as the previous exception for server-side logs; the
+            // client only ever sees this ToolCallException's own message.)
+            try {
+                $application = \app\get($reportId);
+            } catch (\Throwable $e) {
+                throw new \Mcp\Exception\ToolCallException("Report '$reportId' not found", 0, $e);
+            }
+            // Intentional, not a mistake: a report that exists but belongs to
+            // someone else is reported as "not found" (not "forbidden") so we
+            // never confirm that another user's report exists. Ownership is by
+            // email, matching get_report / update_report_status and the app's
+            // other ownership checks.
+            if ($application->email !== $user->getEmail()) {
+                throw new \Mcp\Exception\ToolCallException("Report '$reportId' not found");
+            }
+            if ($caseNumber !== null) {
+                $application->externalId = $caseNumber;
+            }
+            if ($privateNote !== null) {
+                $application->privateComment = $privateNote;
+            }
+            return \app\save($application);
+        });
+
+        return $this->enrich($updated);
+    }
 }

--- a/src/inc/oauth/Repositories.php
+++ b/src/inc/oauth/Repositories.php
@@ -25,6 +25,7 @@ use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 const SCOPES = [
     'reports:read'         => 'Odczyt Twoich zgłoszeń',
     'reports:status:write' => 'Zmiana statusu Twoich zgłoszeń',
+    'reports:notes:write'  => 'Zapisywanie notatek i numeru sprawy w Twoich zgłoszeniach',
 ];
 
 /** Opaque tokens are stored only as SHA-256 hashes. */

--- a/tests/mcp/ReportMcpToolsTest.php
+++ b/tests/mcp/ReportMcpToolsTest.php
@@ -213,4 +213,75 @@ class ReportMcpToolsTest extends DatabaseTestCase
         $this->expectException(RuntimeException::class);
         (new ReportMcpTools())->updateReportStatus($app->id, ReportStatus::Archived);
     }
+
+    public function testSetReportNotesRequiresNotesScope(): void
+    {
+        $app = $this->makeApp('mcp-notes-scope', 'confirmed-waiting', 'a@b.com');
+        // reports:status:write must not be enough to write notes.
+        $this->actAs('a@b.com', ['reports:read', 'reports:status:write']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("requires the 'reports:notes:write' OAuth scope");
+        (new ReportMcpTools())->setReportNotes($app->id, 'RSOW 1/24');
+    }
+
+    public function testSetReportNotesRequiresAtLeastOneField(): void
+    {
+        $app = $this->makeApp('mcp-notes-empty', 'confirmed-waiting', 'owner6@example.com');
+        $this->actAs('owner6@example.com', ['reports:notes:write']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('caseNumber and/or privateNote');
+        (new ReportMcpTools())->setReportNotes($app->id);
+    }
+
+    public function testSetReportNotesUpdatesOwnReport(): void
+    {
+        $app = $this->makeApp('mcp-notes-own', 'confirmed-waiting', 'owner7@example.com');
+        $this->actAs('owner7@example.com', ['reports:notes:write']);
+
+        $result = (new ReportMcpTools())->setReportNotes($app->id, 'RSOW 42/24', 'zadzwonić w środę');
+
+        // Return value reflects the update.
+        self::assertSame('RSOW 42/24', $result['externalId']);
+        self::assertSame('zadzwonić w środę', $result['privateComment']);
+        // externalId is stored in plaintext, so persistence is verifiable directly.
+        self::assertSame('RSOW 42/24', \app\get('mcp-notes-own')->externalId);
+    }
+
+    public function testSetReportNotesOnlyCaseNumberLeavesNoteUntouched(): void
+    {
+        $app = $this->makeApp('mcp-notes-partial', 'confirmed-waiting', 'owner8@example.com');
+        $this->actAs('owner8@example.com', ['reports:notes:write']);
+
+        $result = (new ReportMcpTools())->setReportNotes($app->id, 'RSOW 7/24');
+
+        self::assertSame('RSOW 7/24', $result['externalId']);
+        // An empty note stays at its default and is omitted from the serialised
+        // report (Application::jsonSerialize drops empty externalId/privateComment).
+        self::assertSame('', $result['privateComment'] ?? '', 'note must be left as-is when only caseNumber is given');
+    }
+
+    public function testSetReportNotesRejectsAnotherUsersReport(): void
+    {
+        $app = $this->makeApp('mcp-notes-other', 'confirmed-waiting', 'victim3@example.com');
+        $this->actAs('attacker3@example.com', ['reports:notes:write']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Report 'mcp-notes-other' not found");
+        (new ReportMcpTools())->setReportNotes($app->id, 'RSOW 9/24');
+
+        self::assertSame('', \app\get('mcp-notes-other')->externalId, 'the report must be untouched');
+    }
+
+    public function testSetReportNotesRejectsUnknownReport(): void
+    {
+        // \app\get throws for an unknown id; the tool must still surface a clean
+        // "not found" tool error, not an opaque internal exception.
+        $this->actAs('owner9@example.com', ['reports:notes:write']);
+
+        $this->expectException(\Mcp\Exception\ToolCallException::class);
+        $this->expectExceptionMessage("Report 'does-not-exist' not found");
+        (new ReportMcpTools())->setReportNotes('does-not-exist', 'RSOW 1/24');
+    }
 }


### PR DESCRIPTION
Adds a **`set_report_notes`** MCP tool so an assistant can save a report's private annotations.

## What it adds
- **New scope `reports:notes:write`** (added to the single `SCOPES` registry, so validation, metadata, and the consent screen pick it up automatically).
- **`set_report_notes(reportId, caseNumber?, privateNote?)`** — writes:
  - `caseNumber` → the authority (city guard / police) case number ("NUMER SPRAWY"),
  - `privateNote` → a free-text private note ("UWAGI").

  Both are **private to the user and never sent to the authorities**. At least one must be provided; each given value overwrites the current one. The tool reuses the same write path as the web UI (`SessionApiHandler::setFields`): ownership check inside a row lock (`\semaphore\withLock`, whose `try/finally` releases on error). `privateComment` stays encrypted at rest.

## Notes
- Read-side already works: `get_report`/`list_reports` return `externalId`/`privateComment` (decrypted for the owner); empty values are omitted by `Application::jsonSerialize`.
- Errors are readable tool errors (unknown/again-not-owned report id, or "provide caseNumber and/or privateNote"), not opaque `-32603`.

## Testing
130/130 unit tests green, including new tests: scope required (`reports:status:write` is not enough), at-least-one-field required, own-report update persists, partial update leaves the other field untouched, and another user's report is rejected.

Branches off `main` and is independent of the other open MCP PR; a trivial rebase may be needed depending on merge order.
