### PR TITLE
MCP: create_report_draft + list_categories tools

### DIFF
--- a/API.md
+++ b/API.md
@@ -157,12 +157,12 @@ missing/invalid token it returns `401` with a `WWW-Authenticate: Bearer resource
 header pointing at the protected-resource metadata.
 
 The server lets an assistant read reports, record the authority's response
-(`update_report_status`), and save a report's **private** annotations — the case number and a
-private note (`set_report_notes`). Creating reports, editing the report content that is sent to
-authorities, and fetching binary assets (images/PDF/ZIP) are intentionally out of scope for now.
-Tools reject unknown arguments (`additionalProperties: false`) rather than silently dropping them,
-and domain failures come back as readable tool errors (e.g. an illegal status transition or an
-unknown report id), not opaque internal errors.
+(`update_report_status`), save a report's **private** annotations — the case number and a
+private note (`set_report_notes`) — and create pre-filled **drafts** (`create_report_draft`) for
+the user to finish and send themselves. It cannot send reports, edit already-sent content, or
+fetch binary assets (images/PDF/ZIP). Tools reject unknown arguments (`additionalProperties:
+false`) rather than silently dropping them, and domain failures come back as readable tool errors
+(e.g. an illegal status transition or an unknown report id), not opaque internal errors.
 
 Tools:
 
@@ -177,6 +177,14 @@ Tools:
   * `set_report_notes` — scope `reports:notes:write`. Params: `reportId`, and at least one of
     `caseNumber` (authority case number) / `privateNote`. Both are private to the user and are
     never sent to the authorities; each given value overwrites the current one.
+  * `list_categories` — scope `reports:read`. No params. Returns `{ "categories": [...] }`, each
+    with `id`, `title`, `formal`, `law`, `fine` (PLN), `demeritPoints`.
+  * `create_report_draft` — scope `reports:create`. All params optional: `category` (id, from
+    `list_categories`), `plateId`, `description`, `address`, `lat`, `lng`, `datetime` (ISO 8601),
+    and up to three images — `carImage`, `contextImage`, `thirdImage` — each a base64 data URI
+    (JPEG/PNG, ≤ 2 MB, no URL fetching). Creates a `draft` and returns `{ report, editUrl }`; the
+    user opens `editUrl` to add the required photos and send. The server never sends the report
+    itself.
 
 Every returned report expands its category into `categoryInfo` (`id`, `title`, `formal` wording,
 `law`, `fine` in PLN, `demeritPoints`) alongside the raw `category` number, and its recipient
@@ -191,8 +199,8 @@ clients use mainly for validation).
 
 Authorization-code grant with PKCE (S256), refresh tokens, and Dynamic Client Registration.
 Tokens are opaque (stored as SHA-256 hashes), audience-bound to the `/mcp` resource. Scopes:
-`reports:read`, `reports:status:write`, `reports:notes:write`. The consent step reuses the
-existing Firebase login.
+`reports:read`, `reports:status:write`, `reports:notes:write`, `reports:create`. The consent step
+reuses the existing Firebase login.
 
 ### GET `/.well-known/oauth-authorization-server`
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,12 @@ Users review and revoke connected clients at **`/mcp`** (`/polaczone-aplikacje.h
 | `get_report` | `reports:read` | fetch one report by id |
 | `update_report_status` | `reports:status:write` | record the authority's response |
 | `set_report_notes` | `reports:notes:write` | save a private case number / note (never sent to authorities) |
+| `list_categories` | `reports:read` | list the violation categories |
+| `create_report_draft` | `reports:create` | create a pre-filled **draft** for the user to finish + send |
 
-Creating reports, editing the report content sent to authorities, and downloading binary assets
-(images/PDF/ZIP) are out of scope for now.
+The server never sends reports itself — `create_report_draft` returns an `editUrl` the user opens
+to add the required photos and send. Editing already-sent content and downloading binary assets
+(PDF/ZIP) are out of scope for now.
 
 Tokens are **opaque** (stored hashed, instantly revocable, audience-bound to `/mcp`);
 access tokens live 1h, refresh tokens 30d (sliding). Code: `src/api/mcp/` (server),

--- a/src/inc/mcp/McpServerFactory.php
+++ b/src/inc/mcp/McpServerFactory.php
@@ -15,7 +15,7 @@ function buildServer(): Server {
     // Output schema: `status` is an enum of every known status (from
     // statuses.json); other fields pass through via additionalProperties.
     // Per-status meaning + transitions are in the server instructions, not here.
-    global $STATUSES;
+    global $STATUSES, $CATEGORIES;
     $reportSchema = [
         'type' => 'object',
         'properties' => [
@@ -132,6 +132,48 @@ function buildServer(): Server {
         'additionalProperties' => false,
     ];
 
+    $categoriesOutputSchema = [
+        'type' => 'object',
+        'properties' => ['categories' => ['type' => 'array', 'items' => ['type' => 'object']]],
+        'additionalProperties' => true,
+    ];
+
+    // Input for create_report_draft — every field optional (an empty draft is
+    // valid); the human completes it via the returned editUrl.
+    $createInputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'category' => [
+                'type' => 'integer',
+                // Valid ids come from categories.json (data, not code), so the
+                // enum is generated dynamically — no static list to drift.
+                'enum' => array_keys($CATEGORIES ?? []),
+                'description' => 'Violation category id (see list_categories).',
+            ],
+            'plateId' => ['type' => 'string', 'description' => 'Licence plate, e.g. "ZS1234A".'],
+            'description' => ['type' => 'string', 'description' => 'Free-text description of the violation.'],
+            'address' => ['type' => 'string', 'description' => 'Street address where it happened.'],
+            'lat' => ['type' => 'number', 'description' => 'Latitude.'],
+            'lng' => ['type' => 'number', 'description' => 'Longitude.'],
+            'datetime' => ['type' => 'string', 'description' => 'When it happened, ISO 8601 local time (e.g. 2026-01-08T14:30:00); any timezone offset is ignored.'],
+            'carImage' => ['type' => 'string', 'description' => 'Optional vehicle/plate photo as a base64 data URI (JPEG/PNG, ≤ 2 MB); runs plate recognition.'],
+            'contextImage' => ['type' => 'string', 'description' => 'Optional wider-scene photo as a base64 data URI (JPEG/PNG, ≤ 2 MB).'],
+            'thirdImage' => ['type' => 'string', 'description' => 'Optional third photo as a base64 data URI (JPEG/PNG, ≤ 2 MB).'],
+        ],
+        'additionalProperties' => false,
+    ];
+    $createOutputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'report' => ['type' => 'object'],
+            'editUrl' => [
+                'type' => 'string',
+                'description' => 'Open this to add the required photos and send the report.',
+            ],
+        ],
+        'additionalProperties' => true,
+    ];
+
     return Server::builder()
         ->setServerInfo(
             'Uprzejmie Donoszę',
@@ -142,10 +184,13 @@ function buildServer(): Server {
             'Browse the signed-in user\'s reports (zgłoszenia) with list_reports, '
             . 'fetch one with get_report, record the authority\'s response with '
             . 'update_report_status, and save a private case number or note with '
-            . 'set_report_notes. Each report has a `status` id (see the legend below) '
-            . 'and a categoryInfo object (the violation type, its formal wording and legal '
-            . 'basis). Use the Polish status labels when talking to the user, and only set a '
-            . 'status the current one is allowed to move to.'
+            . 'set_report_notes. Use list_categories to see the violation types, and '
+            . 'create_report_draft to start a new report — it creates a draft the user must '
+            . 'open (editUrl) to add photos and send; the server cannot send reports itself. '
+            . 'Each report has a `status` id (see the legend below) and a categoryInfo object '
+            . '(the violation type, its formal wording and legal basis). Use the Polish status '
+            . 'labels when talking to the user, and only set a status the current one is '
+            . 'allowed to move to.'
             . "\n\nStatus legend (id — label — meaning; allowed transitions):\n" . $statusLegend
         )
         ->setSession(new McpMemcacheSessionStore())
@@ -200,6 +245,36 @@ function buildServer(): Server {
             ),
             inputSchema: $notesInputSchema,
             outputSchema: $reportSchema
+        )
+        ->addTool(
+            [$tools, 'listCategories'],
+            'list_categories',
+            description: 'List the violation categories (id, title, formal wording, legal basis, '
+                . 'fine, demerit points) — pick one for create_report_draft or to interpret a '
+                . 'report\'s category number.',
+            annotations: new ToolAnnotations(
+                readOnlyHint: true,
+                idempotentHint: true,
+                openWorldHint: false
+            ),
+            outputSchema: $categoriesOutputSchema
+        )
+        ->addTool(
+            [$tools, 'createReportDraft'],
+            'create_report_draft',
+            description: 'Create a new DRAFT report for the signed-in user, pre-filled from the '
+                . 'given fields. The draft is NOT sent: a human must open the returned editUrl to '
+                . 'add the required photos and send it. Requires the reports:create scope.',
+            annotations: new ToolAnnotations(
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                // A car image is run through plate recognition, which calls an
+                // external ALPR service — an open-world interaction.
+                openWorldHint: true
+            ),
+            inputSchema: $createInputSchema,
+            outputSchema: $createOutputSchema
         )
         ->build();
 }

--- a/src/inc/mcp/ReportMcpTools.php
+++ b/src/inc/mcp/ReportMcpTools.php
@@ -70,14 +70,7 @@ final class ReportMcpTools {
 
         $category = $CATEGORIES[$application->category] ?? null;
         if ($category) {
-            $report['categoryInfo'] = [
-                'id' => $application->category,
-                'title' => $category->getTitle(),
-                'formal' => $category->getFormal(),
-                'law' => $category->getLaw(),
-                'fine' => $category->getMandate(),          // "mandat" — fine amount in PLN
-                'demeritPoints' => $category->getPoints(),  // "punkty karne"
-            ];
+            $report['categoryInfo'] = self::categorySummary((int) $application->category, $category);
         }
 
         // Expand the recipient authority: `smCity` is only a key (e.g. "Szczecin"),
@@ -95,6 +88,22 @@ final class ReportMcpTools {
         }
 
         return $report;
+    }
+
+    /**
+     * The public shape of a violation category, shared by categoryInfo (on a
+     * report) and list_categories. `fine`/`demeritPoints` are English-friendly
+     * names for the Polish "mandat" (PLN) / "punkty karne".
+     */
+    private static function categorySummary(int $id, \Category $category): array {
+        return [
+            'id' => $id,
+            'title' => $category->getTitle(),
+            'formal' => $category->getFormal(),
+            'law' => $category->getLaw(),
+            'fine' => $category->getMandate(),
+            'demeritPoints' => $category->getPoints(),
+        ];
     }
 
     /**
@@ -175,5 +184,172 @@ final class ReportMcpTools {
         });
 
         return $this->enrich($updated);
+    }
+
+    /**
+     * List the violation categories (id + title, formal wording, legal basis,
+     * fine and demerit points) so the caller can pick one for create_report_draft
+     * or interpret a report's `category` number.
+     *
+     * @return array{categories: array} The categories.
+     */
+    public function listCategories(): array {
+        McpIdentity::requireScope('reports:read');
+        global $CATEGORIES;
+
+        $categories = [];
+        foreach (($CATEGORIES ?? []) as $id => $category) {
+            $categories[] = self::categorySummary((int) $id, $category);
+        }
+
+        return ['categories' => $categories];
+    }
+
+    /**
+     * Create a new DRAFT report for the signed-in user, pre-filled from whatever
+     * the caller can supply. The draft stays in the 'draft' status: a human must
+     * open the returned editUrl to add the required photos and send it — MCP
+     * cannot send a report. Up to three optional images (base64 data URIs) are
+     * run through the same processing pipeline as the web upload.
+     *
+     * @param int|null    $category    Violation category id (see list_categories).
+     * @param string|null $plateId     Licence plate.
+     * @param string|null $description Free-text description of the violation.
+     * @param string|null $address     Street address of the violation.
+     * @param float|null  $lat         Latitude.
+     * @param float|null  $lng         Longitude.
+     * @param string|null $datetime     When it happened (ISO 8601).
+     * @param string|null $carImage     Optional vehicle/plate photo (base64 data URI); runs plate recognition.
+     * @param string|null $contextImage Optional wider-scene photo (base64 data URI).
+     * @param string|null $thirdImage   Optional third photo (base64 data URI).
+     * @return array{report: array, editUrl: string} The draft and the URL to finish it.
+     */
+    public function createReportDraft(
+        ?int $category = null,
+        ?string $plateId = null,
+        ?string $description = null,
+        ?string $address = null,
+        ?float $lat = null,
+        ?float $lng = null,
+        ?string $datetime = null,
+        ?string $carImage = null,
+        ?string $contextImage = null,
+        ?string $thirdImage = null
+    ): array {
+        McpIdentity::requireScope('reports:create');
+        $user = McpIdentity::currentUser();
+
+        global $CATEGORIES;
+        if ($category !== null && !isset($CATEGORIES[$category])) {
+            throw new \Mcp\Exception\ToolCallException(
+                "Unknown category id $category — call list_categories for valid ids."
+            );
+        }
+        // Decode/validate every supplied image up front (keyed by the pipeline's
+        // picture-type name) so a bad one doesn't leave an orphaned draft behind.
+        $images = [];
+        foreach (['carImage' => $carImage, 'contextImage' => $contextImage, 'thirdImage' => $thirdImage] as $slot => $dataUri) {
+            if ($dataUri !== null) {
+                $images[$slot] = self::decodeImageDataUri($dataUri);
+            }
+        }
+
+        // withUser records the creating client's User-Agent; a programmatic MCP
+        // client may not send one, and the entry point turns the resulting
+        // undefined-key warning into an error. Default it so headerless clients
+        // can still create a draft.
+        if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+            $_SERVER['HTTP_USER_AGENT'] = 'MCP';
+        }
+
+        $draft = \app\Application::withUser($user);
+        // A fresh draft has no history/comments/extensions yet; initialise them
+        // so the stored record round-trips cleanly on re-read (Application::
+        // withJson normalises these to arrays).
+        $draft->statusHistory = [];
+        $draft->comments = [];
+        $draft->extensions = [];
+        if ($category !== null) {
+            $draft->category = $category;
+        }
+        if ($plateId !== null) {
+            $carInfo = new \stdClass();
+            $carInfo->plateId = strtoupper(\cleanWhiteChars($plateId));
+            $draft->carInfo = $carInfo;
+        }
+        if ($description !== null) {
+            $draft->userComment = \capitalizeSentence($description);
+        }
+        if ($address !== null) {
+            $draft->address->address = $address;
+        }
+        if ($lat !== null) {
+            $draft->address->lat = $lat;
+        }
+        if ($lng !== null) {
+            $draft->address->lng = $lng;
+        }
+        if ($datetime !== null) {
+            try {
+                $draft->date = (new \DateTime($datetime))->format(\DT_FORMAT);
+            } catch (\Throwable $e) {
+                throw new \Mcp\Exception\ToolCallException(
+                    "Invalid datetime '$datetime' — use ISO 8601, e.g. 2026-01-08T14:30:00."
+                );
+            }
+        }
+        \app\save($draft);
+
+        if ($images) {
+            // Reuse the web upload pipeline (resize, thumbnail, and plate
+            // recognition for carImage) so MCP-supplied photos are processed
+            // identically to the web.
+            foreach ($images as $pictureType => $bytes) {
+                \uploadImage($draft->id, $pictureType, $bytes, $draft->date ?? null, false, null);
+            }
+            $draft = \app\get($draft->id);
+            // carImage's plate recognition resets carInfo; re-apply the caller's
+            // explicit plate so it wins over ALPR (preserving the other
+            // recognised fields).
+            if ($plateId !== null && isset($images['carImage'])) {
+                if (!isset($draft->carInfo)) {
+                    $draft->carInfo = new \stdClass();
+                }
+                $draft->carInfo->plateId = strtoupper(\cleanWhiteChars($plateId));
+                \app\save($draft);
+            }
+        }
+
+        return [
+            'report' => json_decode(json_encode($draft), true) ?? [],
+            'editUrl' => \BASE_URL . 'app/new?edit=' . $draft->id,
+        ];
+    }
+
+    // Matches SessionApiHandler::MAX_IMAGE_UPLOAD_BYTES (the web upload cap).
+    private const MAX_IMAGE_BYTES = 2 * 1024 * 1024;
+
+    /** Decode a base64 image data URI to raw bytes, or fail with a readable error. */
+    private static function decodeImageDataUri(string $dataUri): string {
+        if (!preg_match('#^data:image/[a-z.+-]+;base64,#i', $dataUri, $matches)) {
+            throw new \Mcp\Exception\ToolCallException(
+                'image must be a base64 data URI, e.g. "data:image/jpeg;base64,...".'
+            );
+        }
+        $bytes = base64_decode(substr($dataUri, strlen($matches[0])), true);
+        if ($bytes === false || $bytes === '') {
+            throw new \Mcp\Exception\ToolCallException('image is not valid base64 data.');
+        }
+        if (strlen($bytes) > self::MAX_IMAGE_BYTES) {
+            throw new \Mcp\Exception\ToolCallException('image is too large (max 2 MB).');
+        }
+        // Only JPEG/PNG are handled by the upload pipeline. Validate here (before
+        // any draft is created) so an unsupported type is a readable tool error
+        // rather than an orphaned draft + opaque internal error later.
+        $info = @getimagesizefromstring($bytes);
+        if ($info === false || !in_array($info['mime'] ?? '', ['image/jpeg', 'image/png'], true)) {
+            throw new \Mcp\Exception\ToolCallException('image must be a JPEG or PNG.');
+        }
+        return $bytes;
     }
 }

--- a/src/inc/oauth/Repositories.php
+++ b/src/inc/oauth/Repositories.php
@@ -26,6 +26,7 @@ const SCOPES = [
     'reports:read'         => 'Odczyt Twoich zgłoszeń',
     'reports:status:write' => 'Zmiana statusu Twoich zgłoszeń',
     'reports:notes:write'  => 'Zapisywanie notatek i numeru sprawy w Twoich zgłoszeniach',
+    'reports:create'       => 'Tworzenie wersji roboczych zgłoszeń w Twoim imieniu',
 ];
 
 /** Opaque tokens are stored only as SHA-256 hashes. */

--- a/tests/mcp/CreateReportDraftImageTest.php
+++ b/tests/mcp/CreateReportDraftImageTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace UprzejmieDonosze\Tests\Mcp;
+
+require_once __DIR__ . '/../../export/inc/mcp/McpIdentity.php';
+require_once __DIR__ . '/../../export/inc/mcp/ReportMcpTools.php';
+require_once __DIR__ . '/../../export/inc/API.php';
+
+use mcp\McpIdentity;
+use mcp\ReportMcpTools;
+use PHPUnit\Framework\TestCase;
+use user\User;
+
+/**
+ * Verifies create_report_draft's optional image is run through the real web
+ * upload pipeline (uploadImage → saveImgAndThumb). Uses a context image so ALPR
+ * (carImage only) is not exercised. Mirrors tests/API/ImageUploadTest.
+ */
+class CreateReportDraftImageTest extends TestCase
+{
+    /** @var list<string> */
+    private array $pathsToRemove = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->pathsToRemove as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        $this->pathsToRemove = [];
+        $_SESSION = [];
+    }
+
+    private function makeJpegDataUri(int $width = 120, int $height = 90): string
+    {
+        $img = imagecreatetruecolor($width, $height);
+        ob_start();
+        imagejpeg($img, null, 90);
+        $bytes = ob_get_clean();
+        imagedestroy($img);
+        return 'data:image/jpeg;base64,' . base64_encode($bytes);
+    }
+
+    public function testCreateReportDraftWithImageRunsPipeline(): void
+    {
+        $_SESSION['user_id'] = 'phpunit-user-id';
+        $_SESSION['user_email'] = 'draft-img@example.com';
+        $user = new User();
+        $user->data->email = 'draft-img@example.com';
+        \user\save($user);
+
+        McpIdentity::set($user);
+        McpIdentity::setScopes(['reports:create']);
+
+        $result = (new ReportMcpTools())->createReportDraft(
+            plateId: 'zs 1234a',
+            description: 'auto na chodniku',
+            contextImage: $this->makeJpegDataUri()
+        );
+
+        $report = $result['report'];
+        $this->pathsToRemove[] = ROOT . $report['contextImage']['url'];
+        $this->pathsToRemove[] = ROOT . $report['contextImage']['thumb'];
+
+        self::assertSame('draft', $report['status']);
+        self::assertNotEmpty($report['contextImage']['url']);
+        self::assertNotEmpty($report['contextImage']['thumb']);
+        self::assertSame(120, $report['contextImage']['width']);
+        self::assertSame(90, $report['contextImage']['height']);
+        self::assertFileExists(ROOT . $report['contextImage']['url']);
+        // The supplied plate survives alongside an uploaded image.
+        self::assertSame('ZS 1234A', $report['carInfo']['plateId']);
+    }
+}

--- a/tests/mcp/ReportMcpToolsTest.php
+++ b/tests/mcp/ReportMcpToolsTest.php
@@ -284,4 +284,112 @@ class ReportMcpToolsTest extends DatabaseTestCase
         $this->expectExceptionMessage("Report 'does-not-exist' not found");
         (new ReportMcpTools())->setReportNotes('does-not-exist', 'RSOW 1/24');
     }
+
+    public function testListCategoriesRequiresReadScope(): void
+    {
+        $this->actAs('a@b.com', []);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("requires the 'reports:read' OAuth scope");
+        (new ReportMcpTools())->listCategories();
+    }
+
+    public function testListCategoriesReturnsCatalog(): void
+    {
+        $this->actAs('cat-reader@example.com', ['reports:read']);
+
+        $result = (new ReportMcpTools())->listCategories();
+
+        self::assertArrayHasKey('categories', $result);
+        self::assertNotEmpty($result['categories']);
+        $first = $result['categories'][0];
+        foreach (['id', 'title', 'formal', 'law', 'fine', 'demeritPoints'] as $key) {
+            self::assertArrayHasKey($key, $first);
+        }
+        self::assertIsInt($first['id']);
+    }
+
+    public function testCreateReportDraftRequiresCreateScope(): void
+    {
+        // Neither read nor status:write may create.
+        $this->actAs('a@b.com', ['reports:read', 'reports:status:write']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("requires the 'reports:create' OAuth scope");
+        (new ReportMcpTools())->createReportDraft(category: 8);
+    }
+
+    public function testCreateReportDraftCreatesPrefilledDraft(): void
+    {
+        $this->actAs('creator@example.com', ['reports:create']);
+
+        $result = (new ReportMcpTools())->createReportDraft(
+            category: 8,
+            plateId: 'zs 1234a',
+            description: 'auto na chodniku',
+            address: 'Mazurska 43, Szczecin',
+            lat: 53.43,
+            lng: 14.55,
+            datetime: '2026-01-08T14:30:00'
+        );
+
+        $report = $result['report'];
+        self::assertSame('draft', $report['status']);
+        self::assertSame(8, $report['category']);
+        self::assertSame('ZS 1234A', $report['carInfo']['plateId'], 'plate is whitespace-cleaned + upper-cased (same as the web)');
+        self::assertStringContainsString('chodniku', $report['userComment']);
+        self::assertSame('Mazurska 43, Szczecin', $report['address']['address']);
+        self::assertSame('2026-01-08T14:30:00', $report['date']);
+        self::assertStringContainsString('app/new?edit=' . $report['id'], $result['editUrl']);
+        // Persisted as a draft the human can still edit.
+        self::assertSame('draft', \app\get($report['id'])->status);
+    }
+
+    public function testCreateReportDraftRejectsUnknownCategory(): void
+    {
+        $this->actAs('creator2@example.com', ['reports:create']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unknown category id');
+        (new ReportMcpTools())->createReportDraft(category: 999999);
+    }
+
+    public function testCreateReportDraftRejectsInvalidImageDataUri(): void
+    {
+        $this->actAs('creator3@example.com', ['reports:create']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('base64 data URI');
+        (new ReportMcpTools())->createReportDraft(description: 'x', contextImage: 'not-a-data-uri');
+    }
+
+    public function testCreateReportDraftRejectsOversizedImage(): void
+    {
+        $this->actAs('creator4@example.com', ['reports:create']);
+
+        // > 2 MB decoded — rejected before any draft is created.
+        $oversized = 'data:image/jpeg;base64,' . base64_encode(str_repeat('a', 2 * 1024 * 1024 + 1));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('too large');
+        (new ReportMcpTools())->createReportDraft(contextImage: $oversized);
+    }
+
+    public function testCreateReportDraftRejectsUnsupportedImageType(): void
+    {
+        $this->actAs('creator5@example.com', ['reports:create']);
+
+        // A valid GIF (right size, valid base64) but not a JPEG/PNG the pipeline
+        // handles — rejected up front, before any draft is created.
+        $gd = imagecreatetruecolor(10, 10);
+        ob_start();
+        imagegif($gd);
+        $gif = ob_get_clean();
+        imagedestroy($gd);
+        $dataUri = 'data:image/gif;base64,' . base64_encode($gif);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('JPEG or PNG');
+        (new ReportMcpTools())->createReportDraft(contextImage: $dataUri);
+    }
 }


### PR DESCRIPTION
> **Stacked on #103** — this branch is built on top of `feat/mcp-legibility`, so its diff currently shows #103's commit too. Please merge **#103 first**; once it lands, this collapses to just the `create_report_draft`/`list_categories` commit on rebase. It reuses #103's category shape via a shared helper (no duplication).

Adds MCP tools to **draft a new report** and to **enumerate categories**.

## What it adds
- **New scope `reports:create`**.
- **`list_categories`** (scope `reports:read`) — the violation catalog: `id`, `title`, `formal` wording, `law`, `fine` (PLN), `demeritPoints`. Lets a client pick a category for a draft, or interpret a report's raw `category` number.
- **`create_report_draft`** (scope `reports:create`) — creates a pre-filled **draft** and returns `{ report, editUrl }`. Optional: `category`, `plateId`, `description`, `address`, `lat`, `lng`, `datetime`, and up to three images `carImage` / `contextImage` / `thirdImage`.

## Design
- **The server never sends a report.** The draft stays in `draft`; the returned `editUrl` (`/app/new?edit=<id>`) is where the human adds photos and sends.
- **Category shape is shared with #103** via a single `categorySummary()` helper — `categoryInfo` (on a report, from #103) and `list_categories` emit the identical structure. `category` is validated against a **dynamic enum** of the current ids (generated from `categories.json`), so there's no static list to drift.
- **Images** — the three slots match the app (`carImage`/`contextImage`/`thirdImage`); each optional, a **base64 data URI** (no URL fetching → no SSRF), **≤ 2 MB**, **JPEG/PNG only** (validated up front — no orphaned draft), run through the *same* pipeline as the web (`uploadImage`: resize/thumbnail, and plate recognition for `carImage`). An explicit `plateId` **wins over** ALPR's reading; a missing `User-Agent` is defaulted (headerless clients); `openWorldHint` reflects the external ALPR call.

## Testing
136/136 unit tests green (union of #103 + this PR), including: scope enforcement, prefilled-draft creation, unknown-category / invalid-image / oversized-image / unsupported-format rejection, and an end-to-end image test that runs a generated JPEG through the real pipeline (context image, with cleanup).
