### PR TITLE
Split monthly reports chart into SM and Policja

### DIFF
--- a/src/inc/store/GlobalStats.php
+++ b/src/inc/store/GlobalStats.php
@@ -71,23 +71,56 @@ function statsByDay(bool $useCache=true){
 }
 
 /**
- * Returns number of new applications (by creation month)
- * in last year.
+ * Returns number of new applications (by creation month) in last year,
+ * split into the ones addressed to Straż Miejska and the ones addressed
+ * to Policja, plus the number of new users.
+ *
+ * Rows are [month, smCnt, policeCnt, usersCnt]; smCnt + policeCnt is the
+ * same total this function used to return as a single column.
+ *
+ * @SuppressWarnings(PHPMD.CamelCaseVariableName)
  */
 function statsByYear(bool $useCache=true){
 
-    $stats = \cache\get(Type::GlobalStats, "statsByYear");
+    // Cache key is versioned because the row shape changed: an entry written by
+    // the previous single-column version would feed the user count into the
+    // Policja series until it expired.
+    $stats = \cache\get(Type::GlobalStats, "statsByYear2");
     if($useCache && $stats){
         return $stats;
     }
 
+    global $SM_ADDRESSES, $POLICE_ADDRESSES;
+
+    // A report only ever stores the lowercased unit key (Application::smCity),
+    // so the recipient has to be derived the way SM::resolve() derives it at
+    // render time: #stopagresji always goes to Policja, otherwise sm.json wins
+    // over police.json for the handful of keys present in both, and anything
+    // unresolvable falls back to the SM side ($SM_ADDRESSES['_nieznane']).
+    // Folding that together, a report is Policja iff stopAgresji is set or its
+    // key is police-only -- which is the single list the query needs.
+    $policeOnly = array_values(array_diff(
+        array_keys($POLICE_ADDRESSES),
+        array_keys($SM_ADDRESSES)
+    ));
+
     $sql = <<<SQL
-        with a as (
-            select substr(json_extract(value, '$.added'), 1, 7) as 'month',
-                count(key) as cnt
-            from applications
-            where json_extract(value, '$.status') not in ('draft', 'ready')
-                and json_extract(value, '$.added') >= date('now', '-24 months')
+        with police_keys as (
+            select p.value as k from json_each(:policeKeys) p
+        ), classified as (
+            select substr(json_extract(app.value, '$.added'), 1, 7) as 'month',
+                case when coalesce(json_extract(app.value, '$.stopAgresji'), 0)
+                        or lower(coalesce(json_extract(app.value, '$.smCity'), ''))
+                            in (select k from police_keys)
+                     then 1 else 0 end as is_police
+            from applications app
+            where json_extract(app.value, '$.status') not in ('draft', 'ready')
+                and json_extract(app.value, '$.added') >= date('now', '-24 months')
+        ), a as (
+            select month,
+                sum(1 - is_police) as sm_cnt,
+                sum(is_police) as police_cnt
+            from classified
             group by 1
         ), u as (
             select substr(json_extract(value, '$.added'), 1, 7) as 'month',
@@ -97,7 +130,8 @@ function statsByYear(bool $useCache=true){
             group by 1
         )
         select a.month,
-            a.cnt as acnt,
+            a.sm_cnt as smcnt,
+            a.police_cnt as pcnt,
             u.cnt as ucnt
         from a
         left outer join u on a.month = u.month
@@ -105,8 +139,10 @@ function statsByYear(bool $useCache=true){
         limit 24;
     SQL;
 
-    $stats = \store\query($sql)->fetchAll(\PDO::FETCH_NUM);
-    \cache\set(Type::GlobalStats, 'statsByYear', $stats);
+    $stmt = \store\prepare($sql);
+    $stmt->execute([':policeKeys' => json_encode($policeOnly)]);
+    $stats = $stmt->fetchAll(\PDO::FETCH_NUM);
+    \cache\set(Type::GlobalStats, 'statsByYear2', $stats);
     return $stats;
 }
 

--- a/src/js/sites/statistics.js
+++ b/src/js/sites/statistics.js
@@ -162,13 +162,23 @@ document.addEventListener("DOMContentLoaded", function () {
     },
     plotOptions: {
       column: {
+        // grouping:false keeps every stack drawn at the same x, so the users
+        // bar stays overlaid on the reports bar instead of sitting beside it.
         grouping: false,
+        stacking: "normal",
         shadow: false,
-        borderWidth: 0
+        // 2px of surface between the SM and Policja segments so the split
+        // reads as two marks rather than one bar with a colour change.
+        borderWidth: 2,
+        borderColor: "#ffffff"
       },
       series: {
         pointWidth: barWidth
       }
+    },
+    // Two report series share a bar, so colour alone no longer identifies them.
+    legend: {
+      enabled: true
     },
     xAxis: {
       tickWidth: 0,
@@ -176,12 +186,21 @@ document.addEventListener("DOMContentLoaded", function () {
     },
     series: [
       {
-        name: "Nowe zgłoszenia",
-        color: "#009C7F"
+        name: "Zgłoszenia – Straż Miejska",
+        color: "#009C7F",
+        stack: "apps"
+      },
+      {
+        name: "Zgłoszenia – Policja",
+        color: "#1F63B8",
+        stack: "apps"
       },
       {
         name: "Nowi użytkownicy",
         color: "#e9c200",
+        // own stack, so it stays a separate overlaid bar rather than piling
+        // on top of the reports total
+        stack: "users",
         pointPadding: 0.4,
         pointPlacement: 0.2,
         pointWidth: barWidth * 0.7
@@ -199,6 +218,13 @@ document.addEventListener("DOMContentLoaded", function () {
         chartOptions: {
           chart: {
             height: 250
+          },
+          plotOptions: {
+            // bars get narrow here, so a 2px separator would eat too much of
+            // the smaller segment
+            column: {
+              borderWidth: 1
+            }
           }
         }
       }]

--- a/tests/store/GlobalStatsTest.php
+++ b/tests/store/GlobalStatsTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace UprzejmieDonosze\Tests\Store;
+
+use UprzejmieDonosze\Tests\DatabaseTestCase;
+
+/**
+ * Covers the Policja/SM split in \global_stats\statsByYear().
+ *
+ * A report only stores the lowercased unit key, so the recipient has to be
+ * re-derived the way SM::resolve() derives it at render time. These tests pin
+ * that derivation down: the unit keys come out of the live config rather than
+ * being hardcoded, so a renamed unit fails loudly instead of silently moving a
+ * report to the wrong side of the bar.
+ *
+ * The shared test database already holds rows, so every assertion is a delta
+ * against a baseline reading rather than an absolute count.
+ */
+class GlobalStatsTest extends DatabaseTestCase
+{
+    private const EMAIL = 'stats-split@nieradka.net';
+
+    protected function tearDown(): void
+    {
+        // statsByYear() writes through to memcached even when asked to skip the
+        // read; without this the rolled-back fixture rows would stay visible to
+        // whatever runs next.
+        \cache\delete(\cache\Type::GlobalStats, 'statsByYear2');
+        parent::tearDown();
+    }
+
+    /**
+     * @return array{smOnly: string, policeOnly: string, both: ?string}
+     */
+    private function configKeys(): array
+    {
+        global $SM_ADDRESSES, $POLICE_ADDRESSES;
+        $sm = array_keys($SM_ADDRESSES);
+        $police = array_keys($POLICE_ADDRESSES);
+
+        $smOnly = array_values(array_diff($sm, $police, ['_nieznane']));
+        $policeOnly = array_values(array_diff($police, $sm));
+        $both = array_values(array_intersect($sm, $police));
+
+        self::assertNotEmpty($smOnly, 'sm.json has no key of its own');
+        self::assertNotEmpty($policeOnly, 'police.json has no key of its own');
+
+        return [
+            'smOnly' => $smOnly[0],
+            'policeOnly' => $policeOnly[0],
+            'both' => $both[0] ?? null,
+        ];
+    }
+
+    private function insertApp(string $key, ?string $smCity, bool $stopAgresji, string $status): void
+    {
+        $stmt = \store\store()->prepare(
+            'INSERT INTO applications ("key", value, email) VALUES (:k, :v, :e)'
+        );
+        $stmt->execute([
+            ':k' => $key,
+            ':v' => json_encode([
+                'added' => date('Y-m-d\TH:i:s'),
+                'status' => $status,
+                'smCity' => $smCity,
+                'stopAgresji' => $stopAgresji,
+            ], JSON_UNESCAPED_UNICODE),
+            ':e' => self::EMAIL,
+        ]);
+    }
+
+    /**
+     * @return array{0: int, 1: int} [smCnt, policeCnt] for the current month
+     */
+    private function currentMonth(): array
+    {
+        $month = date('Y-m');
+        foreach (\global_stats\statsByYear(useCache: false) as $row) {
+            if ($row[0] === $month) {
+                return [(int)$row[1], (int)$row[2]];
+            }
+        }
+        return [0, 0];
+    }
+
+    public function testRowShapeIsMonthSmPoliceUsers(): void
+    {
+        // The shared test database holds no report from the last 24 months, so
+        // seed one rather than asserting against whatever happens to be there.
+        $keys = $this->configKeys();
+        $this->insertApp('t-shape-1', $keys['smOnly'], false, 'confirmed-waiting');
+
+        $rows = \global_stats\statsByYear(useCache: false);
+        self::assertNotEmpty($rows, 'no stats rows to inspect');
+        self::assertCount(4, $rows[0], 'expected [month, sm, police, users]');
+        self::assertMatchesRegularExpression('/^\d{4}-\d{2}$/', $rows[0][0]);
+    }
+
+    public function testStopAgresjiCountsAsPolice(): void
+    {
+        $keys = $this->configKeys();
+        [$sm0, $police0] = $this->currentMonth();
+
+        // #stopagresji wins regardless of the key -- even one owned by SM.
+        $this->insertApp('t-sa-1', $keys['smOnly'], true, 'confirmed-waiting');
+
+        [$sm1, $police1] = $this->currentMonth();
+        self::assertSame($police0 + 1, $police1);
+        self::assertSame($sm0, $sm1);
+    }
+
+    public function testPoliceOnlyKeyCountsAsPolice(): void
+    {
+        $keys = $this->configKeys();
+        [$sm0, $police0] = $this->currentMonth();
+
+        $this->insertApp('t-pol-1', $keys['policeOnly'], false, 'confirmed-waiting');
+
+        [$sm1, $police1] = $this->currentMonth();
+        self::assertSame($police0 + 1, $police1);
+        self::assertSame($sm0, $sm1);
+    }
+
+    public function testSmKeyWinsOverPoliceForKeysPresentInBoth(): void
+    {
+        $keys = $this->configKeys();
+        if ($keys['both'] === null) {
+            self::markTestSkipped('no unit key is present in both sm.json and police.json');
+        }
+        [$sm0, $police0] = $this->currentMonth();
+
+        $this->insertApp('t-both-1', $keys['both'], false, 'confirmed-waiting');
+
+        [$sm1, $police1] = $this->currentMonth();
+        self::assertSame($sm0 + 1, $sm1, 'sm.json must take precedence over police.json');
+        self::assertSame($police0, $police1);
+    }
+
+    /**
+     * SM::resolve() falls back to $SM_ADDRESSES['_nieznane'], which is an SM
+     * object -- so an unresolvable report belongs on the SM side of the bar,
+     * not in a third bucket that would make the totals drift.
+     */
+    public function testUnresolvableKeyCountsAsSm(): void
+    {
+        [$sm0, $police0] = $this->currentMonth();
+
+        $this->insertApp('t-unk-1', '_nieznane', false, 'confirmed-waiting');
+        $this->insertApp('t-unk-2', null, false, 'confirmed-waiting');
+
+        [$sm1, $police1] = $this->currentMonth();
+        self::assertSame($sm0 + 2, $sm1);
+        self::assertSame($police0, $police1);
+    }
+
+    public function testKeyMatchingIsCaseInsensitive(): void
+    {
+        $keys = $this->configKeys();
+        [$sm0, $police0] = $this->currentMonth();
+
+        $this->insertApp('t-case-1', mb_strtoupper($keys['policeOnly']), false, 'confirmed-waiting');
+
+        [$sm1, $police1] = $this->currentMonth();
+        self::assertSame($police0 + 1, $police1);
+        self::assertSame($sm0, $sm1);
+    }
+
+    public function testDraftsAndReadyAreExcluded(): void
+    {
+        $keys = $this->configKeys();
+        [$sm0, $police0] = $this->currentMonth();
+
+        $this->insertApp('t-draft-1', $keys['smOnly'], false, 'draft');
+        $this->insertApp('t-ready-1', $keys['policeOnly'], false, 'ready');
+
+        [$sm1, $police1] = $this->currentMonth();
+        self::assertSame($sm0, $sm1);
+        self::assertSame($police0, $police1);
+    }
+
+    /**
+     * The bar is stacked, so the split must partition exactly the same set the
+     * chart used to show as a single column -- no report counted twice, none
+     * dropped.
+     */
+    public function testSplitPreservesTheTotal(): void
+    {
+        $keys = $this->configKeys();
+        [$sm0, $police0] = $this->currentMonth();
+
+        $fixture = [
+            ['t-tot-1', $keys['smOnly'], false],
+            ['t-tot-2', $keys['policeOnly'], false],
+            ['t-tot-3', $keys['smOnly'], true],
+            ['t-tot-4', '_nieznane', false],
+            ['t-tot-5', null, false],
+        ];
+        foreach ($fixture as [$key, $city, $stopAgresji]) {
+            $this->insertApp($key, $city, $stopAgresji, 'confirmed-waiting');
+        }
+
+        [$sm1, $police1] = $this->currentMonth();
+        self::assertSame(
+            ($sm0 + $police0) + count($fixture),
+            $sm1 + $police1,
+            'sm + police must equal the number of non-draft reports'
+        );
+    }
+}

--- a/tools/stats-police-vs-sm.sql
+++ b/tools/stats-police-vs-sm.sql
@@ -1,0 +1,112 @@
+-- Proporcja zgłoszeń wysłanych na Policję vs Straż Miejską, w rozbiciu na miesiące.
+--
+-- W bazie NIE MA flagi "policja/SM". Adresat jest odtwarzany dopiero przy
+-- renderowaniu, przez SM::resolve() (src/inc/dataclasses/SM.php), z dwóch pól
+-- JSON-a zgłoszenia: $.smCity (klucz jednostki) i $.stopAgresji. Adres e-mail
+-- odbiorcy ($.sent.to) jest zaszyfrowany (Application::encode()), więc nie da
+-- się po nim filtrować. Poniższe zapytanie odtwarza logikę SM::resolve() 1:1:
+--
+--   if ($stopAgresji) return $POLICE_ADDRESSES[$key] ?? $STOP_AGRESJI[$key] ?? $STOP_AGRESJI['default'];
+--   return $SM_ADDRESSES[$key] ?? $POLICE_ADDRESSES[$key] ?? $SM_ADDRESSES['_nieznane'];
+--
+--   stopAgresji = true          -> policja (Police/StopAgresji::isPolice() === true)
+--   klucz w sm.json             -> sm      (SM ma pierwszeństwo przy kluczach obecnych w obu plikach)
+--   klucz w police.json         -> policja
+--   reszta (_nieznane, null)    -> nieznane (w UI renderuje się jako SM-nieznane)
+--
+-- Listy kluczy czytane są wprost z wdrożonych plików configu (readfile + json_each),
+-- więc nie trzeba wklejać ~1000 kluczy i nie zdezaktualizują się po sm-parser.js.
+--
+-- ZAKRES DAT: zmień trzy literały poniżej ('2026-05-01', '2026-08-01' oraz nazwy
+-- w komentarzu). Górna granica jest wyłączna.
+--
+-- URUCHOMIENIE:
+--   ssh nieradka.net 'sqlite3 -readonly -box /var/www/uprzejmiedonosze.net/db/store.sqlite' < tools/stats-police-vs-sm.sql
+--
+-- Wariant liczony po FAKTYCZNEJ dacie wysyłki (a nie utworzenia) -- patrz na dole pliku.
+
+-- =============================================================================
+-- Wariant A: oś czasu = $.added (data utworzenia). Indeksowana, szybka.
+-- Zgłoszenia są wysyłane praktycznie od razu po utworzeniu, więc dla proporcji
+-- miesięcznych różnica względem daty wysyłki jest pomijalna.
+-- =============================================================================
+
+WITH
+cfg(dir) AS (VALUES('/var/www/uprzejmiedonosze.net/webapp/public/api/config/')),
+sm_keys(k)     AS (SELECT j.key FROM cfg, json_each(readfile(cfg.dir||'sm.json'))     j WHERE j.key <> '_nieznane'),
+police_keys(k) AS (SELECT j.key FROM cfg, json_each(readfile(cfg.dir||'police.json')) j),
+wyslane AS (
+  SELECT substr(json_extract(a.value,'$.added'),1,7)           AS miesiac,
+         lower(coalesce(json_extract(a.value,'$.smCity'),''))  AS sm_city,
+         coalesce(json_extract(a.value,'$.stopAgresji'),0)     AS stop_agresji
+  -- INDEXED BY: bez tego planer wybiera applications_status_idx i przemiela
+  -- prawie całą tabelę (409k wierszy); po $.added schodzi do zakresu 3 miesięcy.
+  FROM applications a INDEXED BY applications_added_idx
+  WHERE json_extract(a.value,'$.added') >= '2026-05-01'
+    AND json_extract(a.value,'$.added') <  '2026-08-01'
+    -- statusy po wysyłce; 'archived' celowo pominięte (zgłoszenie mogło zostać
+    -- zarchiwizowane już po wysłaniu -- dopisz je, jeśli ma się liczyć)
+    AND json_extract(a.value,'$.status') IN
+        ('confirmed-waiting','confirmed-waitingE','confirmed-sm',
+         'confirmed-fined','confirmed-instructed','confirmed-ignored','confirmed-complaint')
+),
+klas AS (
+  SELECT miesiac,
+         CASE WHEN stop_agresji                           THEN 'policja'
+              WHEN sm_city IN (SELECT k FROM sm_keys)     THEN 'sm'
+              WHEN sm_city IN (SELECT k FROM police_keys) THEN 'policja'
+              ELSE 'nieznane' END AS adresat
+  FROM wyslane
+)
+SELECT miesiac,
+       count(*)                                          AS total,
+       sum(adresat='policja')                            AS policja,
+       sum(adresat='sm')                                 AS sm,
+       sum(adresat='nieznane')                           AS nieznane,
+       round(100.0*sum(adresat='policja') /count(*),2)   AS policja_pct,
+       round(100.0*sum(adresat='sm')      /count(*),2)   AS sm_pct,
+       round(100.0*sum(adresat='nieznane')/count(*),2)   AS nieznane_pct
+FROM klas
+GROUP BY miesiac
+ORDER BY miesiac;
+
+-- =============================================================================
+-- Wariant B: oś czasu = faktyczna data wysyłki.
+-- $.sent.date jest zaszyfrowane, ale $.statusHistory NIE JEST -- bierzemy
+-- pierwsze przejście na confirmed-waiting / confirmed-waitingE. Okno po $.added
+-- jest poszerzone o miesiąc z każdej strony (indeks nadal działa), a właściwy
+-- filtr idzie po dacie wysyłki. Wolniejsze niż wariant A.
+--
+-- UWAGA: json_each() ma własną kolumnę "value". Niekwalifikowane `value`
+-- w skorelowanym podzapytaniu CICHO rozwiąże się do kolumny json_each zamiast
+-- do applications.value -- zapytanie zwróci wtedy zero wierszy bez błędu.
+-- Dlatego wszystkie odwołania są kwalifikowane aliasem (a.value, h.value, j.key).
+-- =============================================================================
+
+-- WITH
+-- cfg(dir) AS (VALUES('/var/www/uprzejmiedonosze.net/webapp/public/api/config/')),
+-- sm_keys(k)     AS (SELECT j.key FROM cfg, json_each(readfile(cfg.dir||'sm.json'))     j WHERE j.key <> '_nieznane'),
+-- police_keys(k) AS (SELECT j.key FROM cfg, json_each(readfile(cfg.dir||'police.json')) j),
+-- wyslane AS (
+--   SELECT (SELECT min(h.key) FROM json_each(json_extract(a.value,'$.statusHistory')) h
+--            WHERE json_extract(h.value,'$.new') IN ('confirmed-waiting','confirmed-waitingE')) AS wyslano,
+--          lower(coalesce(json_extract(a.value,'$.smCity'),''))  AS sm_city,
+--          coalesce(json_extract(a.value,'$.stopAgresji'),0)     AS stop_agresji
+--   FROM applications a INDEXED BY applications_added_idx
+--   WHERE json_extract(a.value,'$.added') >= '2026-04-01'
+--     AND json_extract(a.value,'$.added') <  '2026-09-01'
+-- ),
+-- klas AS (
+--   SELECT substr(wyslano,1,7) AS miesiac,
+--          CASE WHEN stop_agresji                           THEN 'policja'
+--               WHEN sm_city IN (SELECT k FROM sm_keys)     THEN 'sm'
+--               WHEN sm_city IN (SELECT k FROM police_keys) THEN 'policja'
+--               ELSE 'nieznane' END AS adresat
+--   FROM wyslane
+--   WHERE wyslano >= '2026-05-01' AND wyslano < '2026-08-01'
+-- )
+-- SELECT miesiac, count(*) AS total,
+--        sum(adresat='policja') AS policja, sum(adresat='sm') AS sm, sum(adresat='nieznane') AS nieznane,
+--        round(100.0*sum(adresat='policja')/count(*),2) AS policja_pct,
+--        round(100.0*sum(adresat='sm')     /count(*),2) AS sm_pct
+-- FROM klas GROUP BY miesiac ORDER BY miesiac;


### PR DESCRIPTION
## Summary
- Adds a report/query (`tools/stats-police-vs-sm.sql`) that reproduces `SM::resolve()`'s recipient logic in SQL to count Policja vs Straż Miejska reports monthly.
- Splits the "Nowe zgłoszenia oraz nowi użytkownicy – układ miesięczny" chart on statystyki.html: the single green reports bar becomes a stacked SM (green) / Policja (blue) bar, with `GlobalStats::statsByYear()` reproducing the same recipient classification.
- Adds first test coverage for `GlobalStats` (`tests/store/GlobalStatsTest.php`), asserting the split against unit keys read from the live config rather than hardcoded values.

## Test plan
- [x] `make test` — 157/157 passing (149 existing + 8 new)
- [x] Split query verified against synthetic fixtures covering every classification branch (stopAgresji, sm-only, police-only, keys present in both, `_nieznane`, null, case-insensitivity) in real PHP/PDO/SQLite
- [x] `sm + police` counts confirmed to equal the previous single-column total (no report double-counted or dropped)
- [x] Visual check of the chart in a browser — not done, needs manual verification per project convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)