### PR TITLE
Add Google One Tap auto sign-in for anonymous visitors

### DIFF
--- a/src/js/firebase.js
+++ b/src/js/firebase.js
@@ -3,6 +3,7 @@ import { getAuth, onAuthStateChanged, GoogleAuthProvider, EmailAuthProvider, con
 import * as firebaseui from 'firebaseui';
 
 import Api from './lib/Api'
+import { getFirebaseConfig, getClientId } from './lib/firebaseConfig'
 
 const currentScript = document.currentScript;
 addEventListener("load", () => initLogin(currentScript));
@@ -41,49 +42,6 @@ function initLogin(currentScript) {
 function doLogout() {
     getFirebaseAuth().signOut();
     window.location.replace('/');
-}
-
-function getFirebaseConfig() {
-    const hostName = document.location.hostname
-    if (hostName.includes('staging'))
-        return {
-            apiKey: "AIzaSyDXgjibECwejzudsm3YBQh3O5ponz7ArtI",
-            authDomain: "auth-staging.uprzejmiedonosze.net",
-            databaseURL: "https://uprzejmiedonosze-1494607701827.firebaseio.com",
-            projectId: "uprzejmiedonosze-1494607701827",
-            storageBucket: "uprzejmiedonosze-1494607701827.appspot.com",
-            messagingSenderId: "509860799944",
-            appId: "1:509860799944:web:5e24b16b56db3d44d98cfd"
-        };
-
-    if (hostName.includes('localhost'))
-        return {
-            apiKey: "AIzaSyA-gv2Ju8TfVc9e18sB898lXp0-4JrVIQ8",
-            authDomain: "uprzejmie-donosze-dev.firebaseapp.com",
-            databaseURL: "https://uprzejmie-donosze-dev.firebaseio.com",
-            projectId: "uprzejmie-donosze-dev",
-            storageBucket: "uprzejmie-donosze-dev.appspot.com",
-            messagingSenderId: "961138564803"
-        };
-
-    return {
-        apiKey: "AIzaSyC2vVIN-noxOw_7mPMvkb-AWwOk6qK1OJ8",
-        authDomain: "auth.uprzejmiedonosze.net",
-        databaseURL: "https://uprzejmie-donosze.firebaseio.com",
-        projectId: "uprzejmie-donosze",
-        storageBucket: "uprzejmie-donosze.appspot.com",
-        messagingSenderId: "823788795198",
-        appId: "1:823788795198:web:cc0192100ac2e16324286f"
-    };
-}
-
-function getClientId() {
-    const hostName = document.location.hostname
-    if (hostName.includes('staging'))
-        return '509860799944-7e8qe7knqkcjm5jbi932gg3tmgo657vf.apps.googleusercontent.com'
-    if (hostName.includes('localhost'))
-        return '961138564803-2id1ke8mjl1lr35div1i40dtrn1op369.apps.googleusercontent.com'
-    return '823788795198-inlf6ld2q1o7up7vbkerb4gdu30bm5tu.apps.googleusercontent.com'
 }
 
 function doLogin(signInSuccessUrl) {

--- a/src/js/google-one-tap.js
+++ b/src/js/google-one-tap.js
@@ -1,0 +1,53 @@
+import { initializeApp } from "firebase/app";
+import { getAuth, GoogleAuthProvider, signInWithCredential, connectAuthEmulator } from "firebase/auth";
+
+import Api from './lib/Api'
+import { getFirebaseConfig, getClientId } from './lib/firebaseConfig'
+
+addEventListener("load", initOneTap);
+
+let firebaseAuth = null;
+
+function getFirebaseAuth() {
+    if (!firebaseAuth) {
+        firebaseAuth = getAuth(initializeApp(getFirebaseConfig()))
+        if (document.location.hostname === 'localhost' || document.location.hostname === '127.0.0.1') {
+            connectAuthEmulator(firebaseAuth, "http://127.0.0.1:9099", { disableWarnings: true });
+        }
+    }
+    return firebaseAuth
+}
+
+function initOneTap() {
+    if (!window.google?.accounts?.id) return;
+
+    window.google.accounts.id.initialize({
+        client_id: getClientId(),
+        callback: handleCredentialResponse,
+        auto_select: false,
+        cancel_on_tap_outside: true,
+        use_fedcm_for_prompt: true
+    });
+    window.google.accounts.id.prompt();
+}
+
+async function handleCredentialResponse(googleResponse) {
+    try {
+        const credential = GoogleAuthProvider.credential(googleResponse.credential);
+        const userCredential = await signInWithCredential(getFirebaseAuth(), credential);
+        const accessToken = await userCredential.user.getIdToken();
+        const api = new Api('/api/verify-token');
+        await api.post(null, { "Authorization": `Bearer ${accessToken}` });
+        redirectAfterLogin();
+    } catch (error) {
+        console.error('Google One Tap sign-in failed', error);
+    }
+}
+
+function redirectAfterLogin() {
+    if (window.location.pathname.startsWith('/app')) {
+        window.location.reload();
+    } else {
+        window.location.assign('/app');
+    }
+}

--- a/src/js/lib/firebaseConfig.js
+++ b/src/js/lib/firebaseConfig.js
@@ -1,0 +1,42 @@
+export function getFirebaseConfig() {
+    const hostName = document.location.hostname
+    if (hostName.includes('staging'))
+        return {
+            apiKey: "AIzaSyDXgjibECwejzudsm3YBQh3O5ponz7ArtI",
+            authDomain: "auth-staging.uprzejmiedonosze.net",
+            databaseURL: "https://uprzejmiedonosze-1494607701827.firebaseio.com",
+            projectId: "uprzejmiedonosze-1494607701827",
+            storageBucket: "uprzejmiedonosze-1494607701827.appspot.com",
+            messagingSenderId: "509860799944",
+            appId: "1:509860799944:web:5e24b16b56db3d44d98cfd"
+        };
+
+    if (hostName.includes('localhost'))
+        return {
+            apiKey: "AIzaSyA-gv2Ju8TfVc9e18sB898lXp0-4JrVIQ8",
+            authDomain: "uprzejmie-donosze-dev.firebaseapp.com",
+            databaseURL: "https://uprzejmie-donosze-dev.firebaseio.com",
+            projectId: "uprzejmie-donosze-dev",
+            storageBucket: "uprzejmie-donosze-dev.appspot.com",
+            messagingSenderId: "961138564803"
+        };
+
+    return {
+        apiKey: "AIzaSyC2vVIN-noxOw_7mPMvkb-AWwOk6qK1OJ8",
+        authDomain: "auth.uprzejmiedonosze.net",
+        databaseURL: "https://uprzejmie-donosze.firebaseio.com",
+        projectId: "uprzejmie-donosze",
+        storageBucket: "uprzejmie-donosze.appspot.com",
+        messagingSenderId: "823788795198",
+        appId: "1:823788795198:web:cc0192100ac2e16324286f"
+    };
+}
+
+export function getClientId() {
+    const hostName = document.location.hostname
+    if (hostName.includes('staging'))
+        return '509860799944-7e8qe7knqkcjm5jbi932gg3tmgo657vf.apps.googleusercontent.com'
+    if (hostName.includes('localhost'))
+        return '961138564803-2id1ke8mjl1lr35div1i40dtrn1op369.apps.googleusercontent.com'
+    return '823788795198-inlf6ld2q1o7up7vbkerb4gdu30bm5tu.apps.googleusercontent.com'
+}

--- a/src/templates/base.html.twig
+++ b/src/templates/base.html.twig
@@ -114,7 +114,12 @@
         </script>
 
 
-        {% block headIncludes %}{% endblock %}
+        {% block headIncludes %}
+        {% if not general.isLoggedIn and layout != 'auth' and not dialog %}
+        <script src="https://accounts.google.com/gsi/client" async defer></script>
+        <script src="/js/google-one-tap.js?{{ JS_HASH }}"></script>
+        {% endif %}
+        {% endblock %}
     </head>
     <body class="index {{ mainClass ?? '' }} {{ redesignClass ?? '' }}{% if layout == 'app' or (appShell ?? false) %} app-shell{% endif %}">
         <div data-role="page" class="ui-page" {{iff(dialog,'data-dialog="true"')}}>


### PR DESCRIPTION
## Summary
- Adds a site-wide, non-blocking Google One Tap prompt for logged-out visitors, letting them sign in with their existing Google browser session without visiting `/login.html`.
- Reuses the existing Firebase Google credential + `/api/verify-token` session flow (no backend changes).
- Extracted shared Firebase config/client-id lookup from `firebase.js` into `src/js/lib/firebaseConfig.js` so both the FirebaseUI login page and One Tap use the same source of truth.
- Excludes `/login.html`, `/login-ok.html`, `/logout.html` (layout `auth`) and dialog views from the prompt.
- After a successful auto-login, redirects to `/app` (or reloads in place if already under `/app/*`).

## Test plan
- [x] `make test` (178 tests, OK)
- [x] `parcel build` for `google-one-tap.js` and `firebase.js` succeed standalone
- [ ] Manual verification on shadow/staging: One Tap prompt appears for a browser with an active Google session, sign-in completes and lands on `/app`
- [ ] Confirm no console warnings/errors (previously fixed: FedCM NetworkError noise from deprecated prompt-moment status methods, mandatory-FedCM deprecation warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)